### PR TITLE
Improvements for local livestream caching and bugfixes

### DIFF
--- a/src/accessories/CameraAccessory.ts
+++ b/src/accessories/CameraAccessory.ts
@@ -24,6 +24,8 @@ export class CameraAccessory extends DeviceAccessory {
 
   public readonly cameraConfig: CameraConfig;
 
+  protected streamingDelegate: StreamingDelegate;
+
   constructor(
     platform: EufySecurityPlatform,
     accessory: PlatformAccessory,
@@ -47,6 +49,7 @@ export class CameraAccessory extends DeviceAccessory {
         this.CameraService = this.cameraFunction(accessory);
         this.CameraService.setPrimaryService(true);
         const delegate = new StreamingDelegate(this.platform, eufyDevice, this.cameraConfig, this.platform.api, this.platform.api.hap);
+        this.streamingDelegate = delegate;
         accessory.configureController(delegate.controller);
       } catch (Error) {
         this.platform.log.error(this.accessory.displayName, 'raise error to check and attach livestream function.', Error);
@@ -334,6 +337,9 @@ export class CameraAccessory extends DeviceAccessory {
     motion: boolean,
   ): void {
     this.platform.log.debug(this.accessory.displayName, 'ON DeviceMotionDetected:', motion);
+    if (this.cameraConfig.useCachedLocalLivestream) {
+      this.streamingDelegate.prepareCachedStream();
+    }
     this.service
       .getCharacteristic(this.characteristic.MotionDetected)
       .updateValue(motion);

--- a/src/accessories/CameraAccessory.ts
+++ b/src/accessories/CameraAccessory.ts
@@ -156,6 +156,7 @@ export class CameraAccessory extends DeviceAccessory {
     config.rtsp = config.rtsp ??= false;
     config.forcerefreshsnap =  config.forcerefreshsnap ??= false;
     config.videoConfig = config.videoConfig ??= {};
+    config.useCachedLocalLivestream = config.useCachedLocalLivestream ??= false;
 
     return config;
   }

--- a/src/accessories/CameraAccessory.ts
+++ b/src/accessories/CameraAccessory.ts
@@ -24,7 +24,7 @@ export class CameraAccessory extends DeviceAccessory {
 
   public readonly cameraConfig: CameraConfig;
 
-  protected streamingDelegate: StreamingDelegate;
+  protected streamingDelegate: StreamingDelegate | null = null;
 
   constructor(
     platform: EufySecurityPlatform,
@@ -337,7 +337,7 @@ export class CameraAccessory extends DeviceAccessory {
     motion: boolean,
   ): void {
     this.platform.log.debug(this.accessory.displayName, 'ON DeviceMotionDetected:', motion);
-    if (this.cameraConfig.useCachedLocalLivestream) {
+    if (this.cameraConfig.useCachedLocalLivestream && this.streamingDelegate) {
       this.streamingDelegate.prepareCachedStream();
     }
     this.service

--- a/src/accessories/DoorbellCameraAccessory.ts
+++ b/src/accessories/DoorbellCameraAccessory.ts
@@ -61,7 +61,7 @@ export class DoorbellCameraAccessory extends CameraAccessory {
     if (!this.ring_triggered) {
       this.ring_triggered = true;
       this.platform.log.debug(this.accessory.displayName, 'DoorBell ringing');
-      if (this.cameraConfig.useCachedLocalLivestream) {
+      if (this.cameraConfig.useCachedLocalLivestream && this.streamingDelegate) {
         this.streamingDelegate.prepareCachedStream();
       }
       this.doorbellService

--- a/src/accessories/DoorbellCameraAccessory.ts
+++ b/src/accessories/DoorbellCameraAccessory.ts
@@ -61,6 +61,9 @@ export class DoorbellCameraAccessory extends CameraAccessory {
     if (!this.ring_triggered) {
       this.ring_triggered = true;
       this.platform.log.debug(this.accessory.displayName, 'DoorBell ringing');
+      if (this.cameraConfig.useCachedLocalLivestream) {
+        this.streamingDelegate.prepareCachedStream();
+      }
       this.doorbellService
         .getCharacteristic(this.platform.Characteristic.ProgrammableSwitchEvent)
         .updateValue(this.platform.Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS);

--- a/src/accessories/LocalLivestreamCache.ts
+++ b/src/accessories/LocalLivestreamCache.ts
@@ -5,7 +5,7 @@ import { Station, Device, StreamMetadata, Camera } from 'eufy-security-client';
 import { EufySecurityPlatform } from '../platform';
 import { Logger } from './logger';
 
-export type StationStream = {
+type StationStream = {
   station: Station;
   device: Device;
   metadata: StreamMetadata;
@@ -13,18 +13,137 @@ export type StationStream = {
   audiostream: Readable;
 };
 
+class AudioCache extends Readable {
+
+  private cacheData: Array<Buffer> = [];
+  private pushNewDataImmediately = false;
+
+  constructor() {
+    super();
+  }
+
+  public newAudioData(data: Buffer): void {
+    if (this.pushNewDataImmediately) {
+      this.pushNewDataImmediately = false;
+      this.push(data);
+    } else {
+      this.cacheData.push(data);
+    }
+  }
+
+  public stopCachedStream(): void {
+    this.unpipe();
+    this.destroy();
+  }
+
+  _read(size: number): void {
+    let pushReturn = true;
+    while (this.cacheData.length > 0 && pushReturn) {
+      const data = this.cacheData.shift();
+      pushReturn = this.push(data);
+    }
+    if (pushReturn) {
+      this.pushNewDataImmediately = true;
+    }
+  }
+}
+
+class VideoCache extends Readable {
+
+  private cacheManager: LocalLivestreamCache;
+  private livestreamId: number;
+
+  private cacheData: Array<Buffer> = [];
+  private log: Logger;
+
+  private killTimeout: NodeJS.Timeout | null = null;
+
+  private pushNewDataImmediately = false;
+
+  constructor(id: number, cacheData: Array<Buffer>, manager: LocalLivestreamCache, log: Logger) {
+    super();
+
+    this.livestreamId = id;
+    this.cacheManager = manager;
+    this.cacheData = cacheData;
+    this.log = log;
+    this.resetKillTimeout();
+  }
+
+  public newVideoData(data: Buffer): void {
+
+    if (this.pushNewDataImmediately) {
+      this.pushNewDataImmediately = false;
+      try {
+        if(this.push(data)) {
+          this.resetKillTimeout();
+        }
+      } catch (err) {
+        this.log.debug('Push of new data was not succesful. Most likely the target process (ffmpeg) was already terminated. Error: ' + err);
+      }
+    } else {
+      this.cacheData.push(data);
+    }
+  }
+
+  public stopCachedStream(): void {
+    this.unpipe();
+    this.destroy();
+    if (this.killTimeout) {
+      clearTimeout(this.killTimeout);
+    }
+  }
+
+  private resetKillTimeout(): void {
+    if (this.killTimeout) {
+      clearTimeout(this.killTimeout);
+    }
+    this.killTimeout = setTimeout(() => {
+      this.log.warn('Cached Stream (id: ' + this.livestreamId + ') was terminated due to inactivity.');
+      this.cacheManager.stopCachedStream(this.livestreamId);
+    }, 15000);
+  }
+
+  _read(size: number): void {
+    this.resetKillTimeout();
+    let pushReturn = true;
+    while (this.cacheData.length > 0 && pushReturn) {
+      const data = this.cacheData.shift();
+      pushReturn = this.push(data);
+    }
+    if (pushReturn) {
+      this.pushNewDataImmediately = true;
+    }
+  }
+
+}
+
+type CachedStream = {
+  id: number;
+  videostream: VideoCache;
+  audiostream: AudioCache;
+};
+
 export class LocalLivestreamCache extends EventEmitter {
   
-  private readonly SECONDS_UNTIL_TERMINATION_AFTER_LAST_USER = 45;
+  private readonly SECONDS_UNTIL_TERMINATION_AFTER_LAST_USED = 45;
+  private readonly CONNECTION_ESTABLISHED_TIMEOUT = 5;
 
   private stationStream: StationStream | null;
   private log: Logger;
 
+  private livestreamCount = 0;
+  private iFrameCache: Array<Buffer> = [];
+
+  private cachedStreams: Set<CachedStream> = new Set<CachedStream>();
+
+  private cacheEnabled: boolean;
+
   private connectionTimeout?: NodeJS.Timeout;
   private terminationTimeout?: NodeJS.Timeout;
 
-  private numberOfLivestreamInstances: number;
   private livestreamStartedAt: number | null;
+  private livestreamIsStarting = false;
   
   private readonly platform: EufySecurityPlatform;
   private readonly device: Camera;
@@ -36,8 +155,13 @@ export class LocalLivestreamCache extends EventEmitter {
     this.platform = platform;
     this.device = device;
 
+    // TODO add configuration option for caching
+    this.cacheEnabled = true;
+    if (this.cacheEnabled) {
+      this.log.debug('Livestream caching for ' + this.device.getName() + ' is enabled.');
+    }
+
     this.stationStream = null;
-    this.numberOfLivestreamInstances = 0;
     this.livestreamStartedAt = null;
 
     this.initialize();
@@ -52,8 +176,14 @@ export class LocalLivestreamCache extends EventEmitter {
   }
 
   private initialize() {
+    if (this.stationStream) {
+      this.stationStream.audiostream.unpipe();
+      this.stationStream.audiostream.destroy();
+      this.stationStream.videostream.unpipe();
+      this.stationStream.videostream.destroy();
+    }
     this.stationStream = null;
-    this.numberOfLivestreamInstances = 0;
+    this.iFrameCache = [];
     this.livestreamStartedAt = null;
 
     if (this.connectionTimeout) {
@@ -64,61 +194,48 @@ export class LocalLivestreamCache extends EventEmitter {
     }
   }
 
-  public async getLocalLivestream(): Promise<StationStream> {
-    this.numberOfLivestreamInstances++;
-    this.log.debug('New instance requests livestream from cache. There are currently ' +
-                    this.numberOfLivestreamInstances + ' instance(s) using the livestream.');
+  public async getLocalLivestream(): Promise<CachedStream> {
+    this.log.debug('New instance requests livestream. There were ' +
+                    this.cachedStreams.size + ' instance(s) using the livestream until now.');
     if (this.terminationTimeout) {
       clearTimeout(this.terminationTimeout);
     }
-    if (this.stationStream) {
+    const cachedStream = await this.getCachedStream();
+    if (cachedStream) {
       const runtime = (Date.now() - this.livestreamStartedAt!) / 1000;
-      this.log.debug('Using livestream that was started ' + runtime + ' ago.');
-      return this.stationStream;
+      this.log.debug('Using livestream that was started ' + runtime + ' seconds ago. The cached stream has id: ' + cachedStream.id + '.');
+      return cachedStream;
     } else {
-      this.log.debug('No cached livestream. Start and cache new livestream...');
       return await this.startAndGetLocalLiveStream();
     }
   }
-
-  public releaseLivestream(): void {
-    this.numberOfLivestreamInstances--;
-    this.log.debug('One instance released livestream. There are currently ' +
-                    this.numberOfLivestreamInstances + ' instance(s) using the livestream.');
-    if(this.numberOfLivestreamInstances <= 0) {
-      this.log.debug('All livestream instances have disconnected.');
-      // check if minimum remaining livestream duration is more than 20 percent
-      // of maximum streaming duration or at least 20 seconds
-      // if so the termination of the livestream is scheduled
-      // if a new livestream is initiated in that time (e.g. fetching a snapshot)
-      // the cached livestream can be used
-      const maxStreamingDuration = this.platform.eufyClient.getCameraMaxLivestreamDuration();
-      const runtime = (Date.now() - ((this.livestreamStartedAt !== null) ? this.livestreamStartedAt! : Date.now())) / 1000;
-      if (((maxStreamingDuration - runtime) > maxStreamingDuration*0.2) && (maxStreamingDuration - runtime) > 20) {
-        this.log.debug('Sufficient remaining livestream duration available. Schedule livestream termination in ' +
-                      this.SECONDS_UNTIL_TERMINATION_AFTER_LAST_USER + ' seconds.');
-        if (this.terminationTimeout) {
-          clearTimeout(this.terminationTimeout);
-        }
-        this.terminationTimeout = setTimeout(() => {
-          if (this.numberOfLivestreamInstances <= 0) {
-            this.stopLocalLiveStream();
-          }
-        }, this.SECONDS_UNTIL_TERMINATION_AFTER_LAST_USER * 1000);
-      } else {
-        // stop livestream immediately
-        this.log.debug('Not enough remaining livestream duration. Emptying livestream cache.');
-        this.stopLocalLiveStream();
-      }
-    }
-  }
   
-  private async startAndGetLocalLiveStream(): Promise<StationStream> {
+  private async startAndGetLocalLiveStream(): Promise<CachedStream> {
     return new Promise((resolve, reject) => {
-      this.platform.eufyClient.startStationLivestream(this.device.getSerial());
-      this.once('livestream start', () => {
-        if (this.stationStream) {
-          resolve(this.stationStream);
+      this.log.debug('Start new local livestream...');
+      if (!this.livestreamIsStarting) { // prevent multiple stream starts from eufy station
+        this.livestreamIsStarting = true;
+        this.platform.eufyClient.startStationLivestream(this.device.getSerial());
+      }
+
+      if (this.connectionTimeout) {
+        clearTimeout(this.connectionTimeout);
+      }
+      this.connectionTimeout = setTimeout(() => {
+        this.livestreamIsStarting = false;
+        this.log.error('Local livestream didn\'t start in time. Abort livestream cache request.');
+        reject('no started livestream found');
+      }, this.CONNECTION_ESTABLISHED_TIMEOUT * 1000);
+
+      this.once('livestream start', async () => {
+        if (this.connectionTimeout) {
+          clearTimeout(this.connectionTimeout);
+        }
+        const cachedStream = await this.getCachedStream();
+        if (cachedStream !== null) {
+          this.log.debug('New livestream started. Cached stream has id: ' + cachedStream.id + '.');
+          this.livestreamIsStarting = false;
+          resolve(cachedStream);
         } else {
           reject('no started livestream found');
         }
@@ -126,14 +243,31 @@ export class LocalLivestreamCache extends EventEmitter {
     });
   }
 
-  private stopLocalLiveStream(): void {
-    this.log.debug('Stopping livestream.');
+  private scheduleLivestreamCacheTermination(): void {
+    this.log.debug('Schedule livestream termination in ' + this.SECONDS_UNTIL_TERMINATION_AFTER_LAST_USED + ' seconds.');
+    if (this.terminationTimeout) {
+      clearTimeout(this.terminationTimeout);
+    }
+    this.terminationTimeout = setTimeout(() => {
+      if (this.cachedStreams.size <= 0) {
+        this.stopLocalLiveStream();
+      }
+    }, this.SECONDS_UNTIL_TERMINATION_AFTER_LAST_USED * 1000);
+  }
+
+  public stopLocalLiveStream(): void {
+    this.log.debug('Stopping local livestream.');
     this.platform.eufyClient.stopStationLivestream(this.device.getSerial());
   }
 
   private onStationLivestreamStop(station: Station, device: Device) {
     if (device.getSerial() === this.device.getSerial()) {
       this.log.info(station.getName() + ' livestream for ' + device.getName() + ' has stopped.');
+      this.cachedStreams.forEach((cachedStream) => {
+        cachedStream.audiostream.stopCachedStream();
+        cachedStream.videostream.stopCachedStream();
+        this.removeCachedStream(cachedStream.id);
+      });
       this.initialize();
     }
   }
@@ -146,12 +280,107 @@ export class LocalLivestreamCache extends EventEmitter {
     audiostream: Readable,
   ) {
     if (device.getSerial() === this.device.getSerial()) {
+      this.initialize(); // important to prevent unwanted behaviour when the eufy station emits the 'livestream start' event multiple times
+      // TODO: events for error, close, etc.
+      videostream.on('data', (data) => {
+        if(this.isIFrame(data)) { // cache iFrames to speed up livestream encoding
+          this.iFrameCache = [data];
+        } else if (this.iFrameCache.length > 0) {
+          this.iFrameCache.push(data);
+        }
+
+        this.cachedStreams.forEach((cachedStream) => {
+          cachedStream.videostream.newVideoData(data);
+        });
+      });
+      audiostream.on('data', (data) => {       
+        this.cachedStreams.forEach((cachedStream) => {
+          cachedStream.audiostream.newAudioData(data);
+        });
+      });
+
       this.log.info(station.getName() + ' livestream for ' + device.getName() + ' has started.');
       this.livestreamStartedAt = Date.now();
       this.stationStream = {station, device, metadata, videostream, audiostream};
+      this.log.debug('Stream metadata: ' + JSON.stringify(this.stationStream.metadata));
       
       this.emit('livestream start');
     }
   }
 
+  private getCachedStream(): CachedStream | null {
+    if (this.stationStream) {
+      const id = this.livestreamCount;
+      this.livestreamCount++;
+      if (this.livestreamCount > 1024) {
+        this.livestreamCount = 0;
+      }
+      const videostream = new VideoCache(id, this.iFrameCache, this, this.log);
+      const audiostream = new AudioCache();
+      const cachedStream = { id, videostream, audiostream };
+      this.cachedStreams.add(cachedStream);
+      return cachedStream;
+    } else {
+      return null;
+    }
+  }
+
+  public stopCachedStream(id: number): void {
+    this.cachedStreams.forEach((cStream) => {
+      if (cStream.id === id) {
+        cStream.audiostream.stopCachedStream();
+        cStream.videostream.stopCachedStream();
+        this.removeCachedStream(id);
+      }
+    });
+  }
+
+  private removeCachedStream(id: number): void {
+    let cachedStream: CachedStream | null = null;
+    this.cachedStreams.forEach((cStream) => {
+      if (cStream.id === id) {
+        cachedStream = cStream;
+      }
+    });
+    if (cachedStream !== null) {
+      this.cachedStreams.delete(cachedStream);
+
+      this.log.debug('One cached instance (id: ' + id + ') released livestream. There are now ' +
+                    this.cachedStreams.size + ' instance(s) using the livestream.');
+      if(this.cachedStreams.size === 0) {
+        this.log.debug('All cached instances have terminated.');
+        // check if minimum remaining livestream duration is more than 20 percent
+        // of maximum streaming duration or at least 20 seconds
+        // if so the termination of the livestream is scheduled
+        // if a new livestream is initiated in that time (e.g. fetching a snapshot)
+        // the cached livestream can be used
+        // caching must also be enabled of course
+        const maxStreamingDuration = this.platform.eufyClient.getCameraMaxLivestreamDuration();
+        const runtime = (Date.now() - ((this.livestreamStartedAt !== null) ? this.livestreamStartedAt! : Date.now())) / 1000;
+        if (((maxStreamingDuration - runtime) > maxStreamingDuration*0.2) && (maxStreamingDuration - runtime) > 20 && this.cacheEnabled) {
+          this.log.debug('Sufficient remaining livestream duration available.');
+          this.scheduleLivestreamCacheTermination();
+        } else {
+          // stop livestream immediately
+          if (this.cacheEnabled) {
+            this.log.debug('Not enough remaining livestream duration. Emptying livestream cache.');
+          }
+          this.stopLocalLiveStream();
+        }
+      }
+    }
+  }
+
+  private isIFrame(data: Buffer): boolean {
+    const validValues = [64, 66, 68, 78, 101, 103];
+    if (data !== undefined && data.length > 0) {
+      if (data.length >= 5) {
+        const startcode = [...data.slice(0, 5)];
+        if (validValues.includes(startcode[3]) || validValues.includes(startcode[4])) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
 }

--- a/src/accessories/LocalLivestreamCache.ts
+++ b/src/accessories/LocalLivestreamCache.ts
@@ -148,15 +148,14 @@ export class LocalLivestreamCache extends EventEmitter {
   private readonly platform: EufySecurityPlatform;
   private readonly device: Camera;
   
-  constructor(platform: EufySecurityPlatform, device: Camera, log: Logger) {    
+  constructor(platform: EufySecurityPlatform, device: Camera, cacheEnabled: boolean, log: Logger) {    
     super();
 
     this.log = log;
     this.platform = platform;
     this.device = device;
 
-    // TODO add configuration option for caching
-    this.cacheEnabled = true;
+    this.cacheEnabled = cacheEnabled;
     if (this.cacheEnabled) {
       this.log.debug('Livestream caching for ' + this.device.getName() + ' is enabled.');
     }

--- a/src/accessories/configTypes.ts
+++ b/src/accessories/configTypes.ts
@@ -17,6 +17,7 @@ export type CameraConfig = {
   videoConfigEna: boolean;
   enableCamera: boolean;
   forcerefreshsnap: boolean;
+  useCachedLocalLivestream: boolean;
 };
 
 export type VideoConfig = {

--- a/src/accessories/streamingDelegate.ts
+++ b/src/accessories/streamingDelegate.ts
@@ -109,13 +109,18 @@ export class StreamingDelegate implements CameraStreamingDelegate {
         this.platform = platform;
         this.device = device;
 
-        this.localLivestreamCache = new LocalLivestreamCache(this.platform, this.device, this.log);
-
         this.cameraName = device.getName()!;
 
         this.cameraConfig = cameraConfig;
         this.videoConfig = cameraConfig.videoConfig!;
         this.videoProcessor = ffmpegPath || 'ffmpeg';
+
+        this.localLivestreamCache = new LocalLivestreamCache(
+            this.platform,
+            this.device,
+            this.cameraConfig.useCachedLocalLivestream,
+            this.log,
+            );
 
         this.api.on(APIEvent.SHUTDOWN, () => {
             for (const session in this.ongoingSessions) {


### PR DESCRIPTION
Hi!

Added:
- New plugin configuration option for CameraConfig: `useCachedLocalLivestream` (default: false)
  - if `false`: local livestream caching is disabled. Local livestreams will be stopped immediately after the last instance stopped the transmission. (Still includes the fix for #29)
  - if `true`:  local livestream caching is enabled. Local livestreams will be kept alive for a fixed duration (up to 45 seconds at the moment) after the last instance ended the transmission. This allows consecutive transmissions to start up much faster, but also may increase power consumption for battery powered devices. Also local livestreams will be started immediately after an event (motion, person, doorbell) was triggered, so that start up times are decreased.

Improvement:
- There are now two independent ffmpeg processes used for audio and video streams instead of one for both. This helps also with transmission startup times and with syncing problems between the video and audio stream

Bugfix:
- The previous version of the livestream cache would accumulate past data of the videostream and the user would see the last few seconds of the stream at transmission startup. Now only data up to the last Iframe should be transmitted.

### Still ToDo!

Unfortunately I was not able to implement the new configuration option `useCachedLocalLivestream` into the home bridge-ui-x settings, since this will not work for me for some reason. When I press the settings button home bridge-ui will tell me to edit the configuration manually. Maybe someone could help implement this.
For now the setting uses a default value of `false` which works, but doesn't utilize the best performance for some users I think.