### PR TITLE
fix: plugin crashed if station modes were not written correctly in co…

### DIFF
--- a/src/accessories/StationAccessory.ts
+++ b/src/accessories/StationAccessory.ts
@@ -172,11 +172,16 @@ export class StationAccessory {
       this.modes.push({ hk: 3, eufy: ((this.modes.filter((m) => {
         return m.eufy === 6;
       })[0]) ? 63 : 6) });
-    } else {
+    } else if (this.platform.config.hkOff !== undefined && this.platform.config.hkOff !== null) {
       this.modes.push({
         hk: 3,
         eufy: (this.platform.config.hkOff === 6) ? 63 : this.platform.config.hkOff,
       }); // Enforce 63 if keypad has been selected but not attached to the station
+    } else {
+      this.modes.push({
+        hk: 3,
+        eufy:  63,
+      }); // Enforce 63 if hkOff is not set
     }
 
     this.platform.log.debug(this.accessory.displayName, 'Mapping for station modes: ' + JSON.stringify(this.modes));


### PR DESCRIPTION
…nfig and mode was set do off/disarmed

## Fixed

- Plugin crashed when station mode was set to off/disarmed and config was not setup with guard modes correctly