### PR TITLE
manually trigger alarm

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -37,7 +37,7 @@ body:
     id: plugin_version
     attributes:
       label: Plugin Version
-      description: What version of homebridge are you running?
+      description: What version of the plugin are you running?
       options:
         - v2.0.x (Supported)
         - beta (Best Effort)
@@ -91,6 +91,15 @@ body:
     attributes:
       label: Relevant log output
       description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+    validations:
+      required: true
+
+  - type: textarea
+    id: config
+    attributes:
+      label: config
+      description: Please copy and paste your config json. Please make sure to remove any private information.
       render: shell
     validations:
       required: true

--- a/.npmignore
+++ b/.npmignore
@@ -133,3 +133,12 @@ dist
 .yarn/unplugged
 .yarn/build-state.yml
 .pnp.*
+
+# new workspace
+angular.json
+tsconfig.configui.app.json
+tsconfig.configui.json
+tsconfig.configui.server.json
+tsconfig.configui.spec.json
+tsconfig.plugin.json
+karma.conf.js

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,6 @@
 - crash if first cloud snapshot could not be downloaded
 - smart lock state could be wrong on startup (further improvements needed)
 - fix printed error messages if no stored accessories were found when using the config ui
-- temporary fix for log file rotation crashing
 
 ## 2.0.1 (20.06.2022)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 -   Refactored whole project structure to resemble the new workspace layout (plugin + custom ui)
 -   Reimplementation of device discovery algorithm to better reflect best practices mentioned in [this comment](https://github.com/bropat/eufy-security-client/issues/167#issuecomment-1155388624)
 -   Updated to latest version of eufy-security-client (2.1.0)
+-   Added Dark Mode to config ui
 
 ### Fixed
 -   [Bug]: package.json reqiures the wrong node version #44

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 
-## 2.1.0 (beta) (09/07/2022)
+## 2.1.0 (beta) (11/07/2022)
+
+### Added
+
+- switch to manually reset alarm via homekit
+- switch to manually trigger alarm via homekit (this can be used to trigger the alarm with homekit automations) see #26
 
 ### Changed
 -   Complete redesign of the config ui screen

--- a/src/configui/app/accessory-list/accessory-list.component.css
+++ b/src/configui/app/accessory-list/accessory-list.component.css
@@ -4,6 +4,11 @@
     color: #ffc107;
 }
 
+.config-ui-x-dark-mode .device {
+    background-color: #fff !important;
+    color: black !important;
+  }
+
 .serial {
     font-size: 12px;
 }

--- a/src/configui/app/accessory-list/accessory-list.component.css
+++ b/src/configui/app/accessory-list/accessory-list.component.css
@@ -4,10 +4,10 @@
     color: #ffc107;
 }
 
-.config-ui-x-dark-mode .device {
+.device {
     background-color: #fff !important;
     color: black !important;
-  }
+}
 
 .serial {
     font-size: 12px;

--- a/src/configui/app/app.module.ts
+++ b/src/configui/app/app.module.ts
@@ -38,6 +38,7 @@ import { StationConfigOptionsComponent } from './station-config-options/station-
 import { GuardModesMappingComponent } from './config-options/guard-modes-mapping/guard-modes-mapping.component';
 import { ResetPluginComponent } from './config-options/reset-plugin/reset-plugin.component';
 import { ResetConfirmationComponent } from './reset-confirmation/reset-confirmation.component';
+import { ManualAlarmModesComponent } from './config-options/manual-alarm-modes/manual-alarm-modes.component';
 
 @NgModule({
   declarations: [
@@ -69,6 +70,7 @@ import { ResetConfirmationComponent } from './reset-confirmation/reset-confirmat
     GuardModesMappingComponent,
     ResetPluginComponent,
     ResetConfirmationComponent,
+    ManualAlarmModesComponent,
   ],
   imports: [BrowserModule, FormsModule, NgbModule, AppRoutingModule, FontAwesomeModule],
   providers: [{ provide: LocationStrategy, useClass: HashLocationStrategy }],

--- a/src/configui/app/config-options/advanced-videoconfig/advanced-videoconfig.component.css
+++ b/src/configui/app/config-options/advanced-videoconfig/advanced-videoconfig.component.css
@@ -15,22 +15,22 @@
   padding: .375rem 1rem;
 }
 
-.config-ui-x-dark-mode .accordion-item {
+.config-ui-x-dark-mode * .accordion-item {
   background-color: #2b2b2b !important;
   color: white !important;
 }
 
-.config-ui-x-dark-mode .accordion-button {
+.config-ui-x-dark-mode * .accordion-button {
   background-color: #2b2b2b !important;
   color: white !important;
 }
 
-.config-ui-x-dark-mode .accordion-button:not(.collapsed) {
+.config-ui-x-dark-mode * .accordion-button:not(.collapsed) {
   background-color: #2b2b2b !important;
   color: white !important;
 }
 
-.config-ui-x-dark-mode .accordion-body {
+.config-ui-x-dark-mode * .accordion-body {
   background-color: #2b2b2b !important;
   color: white !important;
 }

--- a/src/configui/app/config-options/advanced-videoconfig/advanced-videoconfig.component.css
+++ b/src/configui/app/config-options/advanced-videoconfig/advanced-videoconfig.component.css
@@ -15,6 +15,11 @@
   padding: .375rem 1rem;
 }
 
+.config-ui-x-dark-mode .accordion-item {
+  background-color: #2b2b2b !important;
+  color: white !important;
+}
+
 .config-ui-x-dark-mode .accordion-button {
   background-color: #2b2b2b !important;
   color: white !important;

--- a/src/configui/app/config-options/advanced-videoconfig/advanced-videoconfig.component.css
+++ b/src/configui/app/config-options/advanced-videoconfig/advanced-videoconfig.component.css
@@ -14,3 +14,18 @@
 .input-group-text {
   padding: .375rem 1rem;
 }
+
+.config-ui-x-dark-mode .accordion-button {
+  background-color: #2b2b2b !important;
+  color: white !important;
+}
+
+.config-ui-x-dark-mode .accordion-button:not(.collapsed) {
+  background-color: #2b2b2b !important;
+  color: white !important;
+}
+
+.config-ui-x-dark-mode .accordion-body {
+  background-color: #2b2b2b !important;
+  color: white !important;
+}

--- a/src/configui/app/config-options/advanced-videoconfig/advanced-videoconfig.component.css
+++ b/src/configui/app/config-options/advanced-videoconfig/advanced-videoconfig.component.css
@@ -14,23 +14,3 @@
 .input-group-text {
   padding: .375rem 1rem;
 }
-
-.config-ui-x-dark-mode * .accordion-item {
-  background-color: #2b2b2b !important;
-  color: white !important;
-}
-
-.config-ui-x-dark-mode * .accordion-button {
-  background-color: #2b2b2b !important;
-  color: white !important;
-}
-
-.config-ui-x-dark-mode * .accordion-button:not(.collapsed) {
-  background-color: #2b2b2b !important;
-  color: white !important;
-}
-
-.config-ui-x-dark-mode * .accordion-body {
-  background-color: #2b2b2b !important;
-  color: white !important;
-}

--- a/src/configui/app/config-options/manual-alarm-modes/manual-alarm-modes.component.html
+++ b/src/configui/app/config-options/manual-alarm-modes/manual-alarm-modes.component.html
@@ -31,6 +31,7 @@
     (e.g. a motion sensor, leak sensor, break-in sensor, ... from another vendor) to trigger the alarm with a homekit automation.<p></p>
     In order to do so, you must specify in which station mode the alarm can be triggered.
     <p></p>
-    Please be aware that this setting can only be set on a per station basis and not per automation.
+    Please be aware that this setting can only be set on a per station basis and not per automation.<br />
+    By default the alarm cause will be shown as 'motion detected' in the eufy app.
   </i></small>
 </div>

--- a/src/configui/app/config-options/manual-alarm-modes/manual-alarm-modes.component.html
+++ b/src/configui/app/config-options/manual-alarm-modes/manual-alarm-modes.component.html
@@ -1,0 +1,36 @@
+<div class="settingsItem row p-3">
+  <span class="mb-4">Manual Alarm Trigger Modes</span>
+
+  <div class="d-flex flex-column flex-sm-row justify-content-between align-items-start align-items-sm-center mb-2">
+    <span>HomeKit Home</span>
+    <div class="form-check form-switch">
+      <input class="form-check-input" type="checkbox" role="switch" [attr.checked]="(value.indexOf(0) !== -1) ? true : null" id="flexSwitchCheckDefault" (change)="toggle(0); update()">
+    </div>
+  </div>
+  <div class="d-flex flex-column flex-sm-row justify-content-between align-items-start align-items-sm-center mb-2">
+    <span>HomeKit Away</span>
+    <div class="form-check form-switch">
+      <input class="form-check-input" type="checkbox" role="switch" [attr.checked]="(value.indexOf(1) !== -1) ? true : null" id="flexSwitchCheckDefault" (change)="toggle(1); update()">
+    </div>
+  </div>
+  <div class="d-flex flex-column flex-sm-row justify-content-between align-items-start align-items-sm-center mb-2">
+    <span>HomeKit Night</span>
+    <div class="form-check form-switch">
+      <input class="form-check-input" type="checkbox" role="switch" [attr.checked]="(value.indexOf(2) !== -1) ? true : null" id="flexSwitchCheckDefault" (change)="toggle(2); update()">
+    </div>
+  </div>
+  <div class="d-flex flex-column flex-sm-row justify-content-between align-items-start align-items-sm-center mb-2">
+    <span>HomeKit Off/Disarmed</span>
+    <div class="form-check form-switch">
+      <input class="form-check-input" type="checkbox" role="switch" [attr.checked]="(value.indexOf(3) !== -1) ? true : null" id="flexSwitchCheckDefault" (change)="toggle(3); update()">
+    </div>
+  </div>
+  
+  <small><i>
+    You can manually trigger (and reset) the stations alarm with a switch. Therefore you can utilize non eufy devices
+    (e.g. a motion sensor, leak sensor, break-in sensor, ... from another vendor) to trigger the alarm with a homekit automation.<p></p>
+    In order to do so, you must specify in which station mode the alarm can be triggered.
+    <p></p>
+    Please be aware that this setting can only be set on a per station basis and not per automation.
+  </i></small>
+</div>

--- a/src/configui/app/config-options/manual-alarm-modes/manual-alarm-modes.component.ts
+++ b/src/configui/app/config-options/manual-alarm-modes/manual-alarm-modes.component.ts
@@ -1,0 +1,57 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { Accessory } from '../../accessory';
+import { PluginService } from '../../plugin.service';
+import { ConfigOptionsInterpreter } from '../config-options-interpreter';
+
+@Component({
+  selector: 'app-manual-alarm-modes',
+  templateUrl: './manual-alarm-modes.component.html',
+  styles: [
+  ],
+})
+export class ManualAlarmModesComponent extends ConfigOptionsInterpreter implements OnInit {
+
+  constructor(pluginService: PluginService) {
+    super(pluginService);
+  }
+
+  ngOnInit(): void {
+    this.readValue();
+  }
+
+  /** Customize from here */
+  /** updateConfig() will overwrite any settings that you'll provide */
+  /** Don't try and 'append'/'push' to arrays this way - add a custom method instead */
+  /** see config option to ignore devices as example */
+
+  /** updateConfig() takes an optional second parameter to specify the accessoriy for which the setting is changed */
+
+  @Input() accessory?: Accessory;
+  value: number[] = [];
+
+  async readValue() {
+    const config = await this.getStationConfig(this.accessory?.uniqueId || '');
+
+    if (config && Array.isArray(config['manualTriggerModes'])) {
+      this.value = config['manualTriggerModes'];
+    }
+  }
+
+  toggle(mode: number) {
+    if (this.value.indexOf(mode) !== -1) {
+      this.value = this.value.filter(v => v !== mode);
+    } else {
+      this.value.push(mode);
+    }
+  }
+
+  update() {
+    this.updateConfig(
+      {
+        manualTriggerModes: this.value,
+      },
+      this.accessory,
+    );
+  }
+
+}

--- a/src/configui/app/station-config-options/station-config-options.component.html
+++ b/src/configui/app/station-config-options/station-config-options.component.html
@@ -9,6 +9,8 @@
     <app-ignore-accessory [accessory]="accessory"></app-ignore-accessory>
     <!-- <hr />
     <app-guard-modes-mapping [accessory]="accessory"></app-guard-modes-mapping> -->
+    <hr />
+    <app-manual-alarm-modes [accessory]="accessory"></app-manual-alarm-modes>
     
   </div>
 </div>

--- a/src/configui/styles.css
+++ b/src/configui/styles.css
@@ -37,3 +37,23 @@
     max-width: 720px;
   }
 }
+
+.config-ui-x-dark-mode .btn-secondary {
+  background-color: #2e2e2e !important;
+  color: #fff !important;
+}
+
+.config-ui-x-dark-mode .btn-success {
+  background-color: #ffa000 !important;
+  color: #fff !important;
+}
+
+/* html[native-dark-active] .btn-secondary {
+  background-color: #2e2e2e !important;
+  color: #fff !important;
+}
+
+html[native-dark-active] .btn-success {
+  background-color: #ffa000 !important;
+  color: #fff !important;
+} */

--- a/src/configui/styles.css
+++ b/src/configui/styles.css
@@ -14,6 +14,11 @@
   border-color: #565e64;
 }
 
+.config-ui-x-dark-mode .form-check-input:checked {
+  background-color: #ffa000 !important;
+  border-color: #565e64;
+}
+
 .settingsItem {
   padding-bottom: 0 !important;
 }

--- a/src/configui/styles.css
+++ b/src/configui/styles.css
@@ -72,3 +72,7 @@
   background-color: #2b2b2b !important;
   color: white !important;
 }
+
+.config-ui-x-dark-mode * .btn-danger {
+  color: white !important;
+}

--- a/src/configui/styles.css
+++ b/src/configui/styles.css
@@ -53,12 +53,22 @@
   color: #fff !important;
 }
 
-/* html[native-dark-active] .btn-secondary {
-  background-color: #2e2e2e !important;
-  color: #fff !important;
+.config-ui-x-dark-mode * .accordion-item {
+  background-color: #2b2b2b !important;
+  color: white !important;
 }
 
-html[native-dark-active] .btn-success {
-  background-color: #ffa000 !important;
-  color: #fff !important;
-} */
+.config-ui-x-dark-mode * .accordion-button {
+  background-color: #2b2b2b !important;
+  color: white !important;
+}
+
+.config-ui-x-dark-mode * .accordion-button:not(.collapsed) {
+  background-color: #2b2b2b !important;
+  color: white !important;
+}
+
+.config-ui-x-dark-mode * .accordion-body {
+  background-color: #2b2b2b !important;
+  color: white !important;
+}

--- a/src/plugin/accessories/StationAccessory.ts
+++ b/src/plugin/accessories/StationAccessory.ts
@@ -16,6 +16,7 @@ export class StationAccessory {
   private station: Station;
 
   private service: Service;
+  private manualTriggerService: Service;
   private alarm_triggered: boolean;
   private modes;
 
@@ -85,6 +86,20 @@ export class StationAccessory {
       .onGet(this.handleSecuritySystemTargetStateGet.bind(this))
       .onSet(this.handleSecuritySystemTargetStateSet.bind(this));
 
+    this.manualTriggerService = 
+      this.accessory.getService(this.platform.Service.Switch) ||
+      this.accessory.addService(this.platform.Service.Switch);
+    
+    this.manualTriggerService.setCharacteristic(
+      this.characteristic.Name,
+      accessory.displayName + ' alarm switch',
+    );
+
+    this.manualTriggerService
+      .getCharacteristic(this.characteristic.On)
+      .onGet(this.handleManualTriggerSwitchStateGet.bind(this))
+      .onSet(this.handleManualTriggerSwitchStateSet.bind(this));
+
     this.eufyStation.on('guard mode', (station: Station, guardMode: number) =>
       this.onStationGuardModePushNotification(station, guardMode),
     );
@@ -130,6 +145,14 @@ export class StationAccessory {
       config.hkOff = config.hkOff ??= this.platform.config.hkOff;
     }
 
+    if (!Array.isArray(config.manualTriggerModes)) {
+      config.manualTriggerModes = [];
+    }
+    this.platform.log.debug(
+      this.accessory.displayName, 'manual alarm will be triggered only in these hk modes: ' + config.manualTriggerModes);
+
+    config.manualAlarmSeconds = config.manualAlarmSeconds ??= 30;
+
     return config;
   }
 
@@ -165,6 +188,14 @@ export class StationAccessory {
     station: Station,
     alarmEvent: AlarmEvent,
   ): void {
+    let currentValue = this.eufyStation.getPropertyValue(PropertyName.StationCurrentMode);
+    if (alarmEvent === 0) {
+      // do not resset alarm if alarm was triggered manually
+      // since the alarm can only be triggered for 30 seconds for now (limitation of eufy-security-client)
+      // this would mean that the alarm is always reset after 30 seconds
+      // see here: https://github.com/bropat/eufy-security-client/issues/178
+      currentValue = -1;
+    }
     switch (alarmEvent) {
       case 2: // Alarm triggered by GSENSOR
       case 3: // Alarm triggered by PIR
@@ -179,11 +210,17 @@ export class StationAccessory {
           .getCharacteristic(this.characteristic.SecuritySystemCurrentState)
           .updateValue(this.characteristic.SecuritySystemCurrentState.ALARM_TRIGGERED); // Alarm !!!
         break;
+      case 0:  // Alarm off by Hub
       case 15: // Alarm off by Keypad
       case 16: // Alarm off by Eufy App
       case 17: // Alarm off by HomeBase button
         this.platform.log.warn('ON StationAlarmEvent - ALARM OFF - alarmEvent:', alarmEvent);
         this.alarm_triggered = false;
+        if (currentValue !== -1) {
+          this.service
+            .getCharacteristic(this.characteristic.SecuritySystemCurrentState)
+            .updateValue(this.convertEufytoHK(currentValue)); // reset alarm state
+        }
         break;
       default:
         this.platform.log.warn('ON StationAlarmEvent - ALARM UNKNOWN - alarmEvent:', alarmEvent);
@@ -192,6 +229,9 @@ export class StationAccessory {
           .updateValue(this.characteristic.StatusFault.GENERAL_FAULT);
         break;
     }
+    this.manualTriggerService
+      .getCharacteristic(this.characteristic.On)
+      .updateValue(this.alarm_triggered);
   }
 
   private mappingHKEufy(): void {
@@ -259,7 +299,7 @@ export class StationAccessory {
   /**
    * Handle requests to get the current value of the 'Security System Target State' characteristic
    */
-  handleSecuritySystemTargetStateGet(): CharacteristicValue {
+  private handleSecuritySystemTargetStateGet(): CharacteristicValue {
     try {
       const currentValue = this.eufyStation.getPropertyValue(PropertyName.StationCurrentMode);
       if (currentValue === -1) {
@@ -298,8 +338,48 @@ export class StationAccessory {
           this.platform.log.error(this.accessory.displayName, 'Changing guard mode to ' + this.getGuardModeName(value) + ' timed out!');
         }, 5000);
       }, 5000);
+
+      this.manualTriggerService
+        .getCharacteristic(this.characteristic.On)
+        .updateValue(false);
     } catch (error) {
       this.platform.log.error(this.accessory.displayName + ': Error Setting security mode!', error);
+    }
+  }
+
+  private handleManualTriggerSwitchStateGet(): CharacteristicValue {
+    return this.alarm_triggered;
+  }
+
+  private async handleManualTriggerSwitchStateSet(value: CharacteristicValue) {
+    if (value) { // trigger alarm if allowed
+      try {
+        const currentValue = this.eufyStation.getPropertyValue(PropertyName.StationCurrentMode);
+        if (currentValue === -1) {
+          throw 'Something wrong with this device';
+        }
+        if (this.stationConfig.manualTriggerModes.indexOf(this.convertEufytoHK(currentValue)) !== -1) {
+          this.eufyStation.triggerStationAlarmSound(this.stationConfig.manualAlarmSeconds)
+            .then(() => this.platform.log.debug(
+              this.accessory.displayName, 'alarm manually triggered for ' + this.stationConfig.manualAlarmSeconds + ' seconds.'))
+            .catch(err => this.platform.log.error(this.accessory.displayName, 'alarm could not be manually triggered: ' + err));
+        } else {
+          setTimeout(() => {
+            // eslint-disable-next-line max-len
+            this.platform.log.info(this.accessory.displayName, 'tried to trigger alarm, but the current station mode prevents the alarm from being triggered. Please look in in the configuration if you want to change this behaviour.');
+            this.manualTriggerService
+              .getCharacteristic(this.characteristic.On)
+              .updateValue(false);
+          }, 1000);
+        }
+      } catch {
+        this.platform.log.error(this.accessory.displayName, 'handleSecuritySystemTargetStateGet', 'Wrong return value');
+        return;
+      }
+    } else { // reset alarm
+      this.eufyStation.resetStationAlarmSound()
+        .then(() => this.platform.log.debug(this.accessory.displayName, 'alarm manually reset'))
+        .catch(err => this.platform.log.error(this.accessory.displayName, 'alarm could not be reset: ' + err));
     }
   }
 

--- a/src/plugin/accessories/configTypes.ts
+++ b/src/plugin/accessories/configTypes.ts
@@ -59,4 +59,6 @@ export type StationConfig = {
   hkAway: number;
   hkNight: number;
   hkOff: number;
+  manualTriggerModes: number[];
+  manualAlarmSeconds: number;
 };

--- a/src/plugin/platform.ts
+++ b/src/plugin/platform.ts
@@ -89,7 +89,7 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
         }),
       }, {
         level: (this.config.enableDetailedLogging) ? 'debug' : 'info',
-        type: 'file',
+        type: 'rotating-file',
         path: this.eufyPath + '/log-lib.log',
         period: '1d',   // daily rotation
         count: 3,        // keep 3 back copies


### PR DESCRIPTION
## Added

- switch to manually reset alarm via homekit
- switch to manually trigger alarm via homekit (this can be used to trigger the alarm with homekit automations) see #26
- dark mode for config ui