### PR TITLE
fix floodlight led switch

### DIFF
--- a/src/plugin/accessories/CameraAccessory.ts
+++ b/src/plugin/accessories/CameraAccessory.ts
@@ -371,6 +371,11 @@ export class CameraAccessory extends DeviceAccessory {
           cameraService.updateCharacteristic(this.platform.Characteristic.NightVision, value as boolean);
           break;
         }
+		
+		case PropertyName.DeviceLight: {
+		  await station.switchLight(this.device, value as boolean);
+		  break;
+		}
 
         default: {
           // eslint-disable-next-line max-len


### PR DESCRIPTION
Light switch does not work since 2.2.10 because of removing the function in https://github.com/homebridge-eufy-security/plugin/commit/6901ed962482da50adcbe821c5e1b7b764fc057e - this PR will bring back the functionality.

(Bug in log is: [09/10/2023 20:39:30]   [EufySecurity-2.2.16]   ERROR   Garden Shouldn't Match 'this.platform.Characteristic.On' light: true)