### PR TITLE
Fix light

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,29 +4,19 @@ You can find the complete detailled changelog for every beta release [here](http
 
 ### Changelog 2.2.17
 
-#### Commits
+#### Added
+- New approach to handling `propertyName` in `CameraAccessory.ts` for more flexibility.
 
-1. **Commit**: 72759f2c
-   - **Author**: Lenoxys
-   - **Date**: Mon Sep 11 13:51:36 2023 +0200
-   - **Description**: Refactored `CameraAccessory.ts` to fix the switch-light issue and enable easier property addition without manual switching logic.
-   - **Credits**: @cixio
-
-2. **Commit**: 9df437d2
-   - **Author**: Lenoxys
-   - **Date**: Mon Sep 11 13:55:40 2023 +0200
-   - **Description**: Refactored accessory handling for flexibility and improved logging; removed `LockControlPoint` getter.
-
-#### Merged Code Changes
-
-- **CameraAccessory.ts & BaseAccessory.ts**
-  - Streamlined `propertyName` handling and enhanced flexibility.
-  - Simplified the characteristic update logic.
-  - `getValue` is now optional, providing more flexibility.
-  - Enhanced logging for accessory handling.
+#### Updated
+- Improved logging formats across `BaseAccessory.ts`, `platform.ts`, and `server.ts`.
+- Fine-tuned execution delays in `BaseAccessory.ts`, `platform.ts`, and `server.ts` for better performance.
+- `BaseAccessory.ts` to make `getValue` optional, allowing for more versatile accessory handling.
   
-- **LockAccessory.ts**
-  - Removed the `LockControlPoint` getter because it is not requested by Apple HomeKit Framework.
+#### Fixed
+- Switch-light issue in `CameraAccessory.ts`.
+
+#### Removed
+  - `LockControlPoint` getter because it is not requested by Apple HomeKit Framework.
 
 ### Changelog 2.2.16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 You can find the complete detailled changelog for every beta release [here](https://github.com/homebridge-eufy-security/plugin/releases).
 
+### Changelog 2.2.17
+
+#### Commits
+
+1. **Commit**: 72759f2c
+   - **Author**: Lenoxys
+   - **Date**: Mon Sep 11 13:51:36 2023 +0200
+   - **Description**: Refactored `CameraAccessory.ts` to fix the switch-light issue and enable easier property addition without manual switching logic.
+   - **Credits**: @cixio
+
+2. **Commit**: 9df437d2
+   - **Author**: Lenoxys
+   - **Date**: Mon Sep 11 13:55:40 2023 +0200
+   - **Description**: Refactored accessory handling for flexibility and improved logging; removed `LockControlPoint` getter.
+
+#### Merged Code Changes
+
+- **CameraAccessory.ts & BaseAccessory.ts**
+  - Streamlined `propertyName` handling and enhanced flexibility.
+  - Simplified the characteristic update logic.
+  - `getValue` is now optional, providing more flexibility.
+  - Enhanced logging for accessory handling.
+  
+- **LockAccessory.ts**
+  - Removed the `LockControlPoint` getter because it is not requested by Apple HomeKit Framework.
+
 ### Changelog 2.2.16
 
 #### Bug Fixes

--- a/src/plugin/accessories/BaseAccessory.ts
+++ b/src/plugin/accessories/BaseAccessory.ts
@@ -157,7 +157,7 @@ export abstract class BaseAccessory extends EventEmitter {
     }
 
     if (onValue) {
-      this.platform.log.info(`${this.accessory.displayName} ON '${serviceType.name} / ${characteristicType.name}'`);
+      this.platform.log.debug(`${this.accessory.displayName} ON '${serviceType.name} / ${characteristicType.name}'`);
       onValue(service, characteristic);
     }
 

--- a/src/plugin/accessories/BaseAccessory.ts
+++ b/src/plugin/accessories/BaseAccessory.ts
@@ -116,7 +116,7 @@ export abstract class BaseAccessory extends EventEmitter {
     serviceSubType?: string;
     name?: string;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    getValue: (data: any) => any;
+    getValue?: (data: any) => any;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     setValue?: (value: any) => any;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -131,11 +131,14 @@ export abstract class BaseAccessory extends EventEmitter {
     // eslint-disable-next-line max-len
     this.platform.log.debug(`${this.accessory.displayName} REGISTER SERVICE '${serviceType.name} / ${characteristic.displayName}': ${characteristic.UUID}`);
 
-    characteristic.onGet(async (data) => {
-      const value = getValue(data);
-      this.platform.log.debug(`${this.accessory.displayName} GET '${serviceType.name} / ${characteristicType.name}': ${value}`);
-      return value;
-    });
+
+    if (getValue) {
+      characteristic.onGet(async (data) => {
+        const value = getValue(data);
+        this.platform.log.debug(`${this.accessory.displayName} GET '${serviceType.name} / ${characteristicType.name}': ${value}`);
+        return value;
+      });
+    }
 
     if (setValue) {
       characteristic.onSet(async (value: CharacteristicValue) => {
@@ -146,10 +149,10 @@ export abstract class BaseAccessory extends EventEmitter {
 
     if (onSimpleValue) {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      this.device.on(onSimpleValue, (device: any, state: any) => {
+      this.device.on(onSimpleValue, (device: any, value: any) => {
         // eslint-disable-next-line max-len
-        this.platform.log.info(`${this.accessory.displayName} ON '${serviceType.name} / ${characteristicType.name} / ${onSimpleValue}': ${state}`);
-        characteristic.updateValue(state);
+        this.platform.log.info(`${this.accessory.displayName} ON '${serviceType.name} / ${characteristicType.name} / ${onSimpleValue}': ${value}`);
+        characteristic.updateValue(value);
       });
     }
 
@@ -162,10 +165,10 @@ export abstract class BaseAccessory extends EventEmitter {
       // Attach the common event handler to each event type
       onMultipleValue.forEach(eventType => {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        this.device.on(eventType as keyof any, (device: any, state: any) => {
+        this.device.on(eventType as keyof any, (device: any, value: any) => {
           // eslint-disable-next-line max-len
-          this.platform.log.info(`${this.accessory.displayName} ON '${serviceType.name} / ${characteristicType.name} / ${eventType}': ${state}`);
-          characteristic.updateValue(state);
+          this.platform.log.info(`${this.accessory.displayName} ON '${serviceType.name} / ${characteristicType.name} / ${eventType}': ${value}`);
+          characteristic.updateValue(value);
         });
       });
     }

--- a/src/plugin/accessories/CameraAccessory.ts
+++ b/src/plugin/accessories/CameraAccessory.ts
@@ -337,48 +337,15 @@ export class CameraAccessory extends DeviceAccessory {
 
       const cameraService = this.getService(this.platform.Service.CameraOperatingMode);
 
-      switch (propertyName) {
-        case PropertyName.DeviceEnabled: {
-          if (characteristic === 'this.platform.Characteristic.On') {
-            this.cameraStatus = { isEnabled: value as boolean, timestamp: Date.now() };
-            await station.enableDevice(this.device, value as boolean);
-            cameraService.updateCharacteristic(this.platform.Characteristic.ManuallyDisabled, !value as boolean);
-          }
-          break;
-        }
+      await this.setPropertyValue(propertyName, value);
 
-        case PropertyName.DeviceMotionDetection: {
-          await station.setMotionDetection(this.device, value as boolean);
-          cameraService.updateCharacteristic(this.platform.Characteristic.CameraOperatingModeIndicator, value as boolean);
-          break;
-        }
-
-        case PropertyName.DeviceStatusLed: {
-          await station.setStatusLed(this.device, value as boolean);
-          cameraService.updateCharacteristic(this.platform.Characteristic.CameraOperatingModeIndicator, value as boolean);
-          break;
-        }
-
-        case PropertyName.DeviceNightvision: {
-          // Convert true to 1 (B&W Night Vision) and false to 0 (off)
-          await station.setNightVision(this.device, Number(value) as number);
-          cameraService.updateCharacteristic(this.platform.Characteristic.NightVision, value as boolean);
-          break;
-        }
-
-        case PropertyName.DeviceAutoNightvision: {
-          await station.setAutoNightVision(this.device, value as boolean);
-          cameraService.updateCharacteristic(this.platform.Characteristic.NightVision, value as boolean);
-          break;
-        }
-
-        default: {
-          // eslint-disable-next-line max-len
-          this.platform.log.error(`${this.accessory.displayName} Shouldn't Match '${characteristic}' ${propertyName}: ${value}`);
-          throw Error;
-          break;
-        }
+      if (characteristic === 'this.platform.Characteristic.On') {
+        this.cameraStatus = { isEnabled: value as boolean, timestamp: Date.now() };
+        characteristic = 'this.platform.Characteristic.ManuallyDisabled';
+        value = !value as boolean;
       }
+
+      cameraService.updateCharacteristic(characteristic, !value as boolean);
 
     } catch (error) {
       this.platform.log.debug(`${this.accessory.displayName} Error setting '${characteristic}' ${propertyName}: ${error}`);

--- a/src/plugin/accessories/LockAccessory.ts
+++ b/src/plugin/accessories/LockAccessory.ts
@@ -62,10 +62,6 @@ export class LockAccessory extends DeviceAccessory {
       this.registerCharacteristic({
         serviceType: this.platform.Service.LockManagement,
         characteristicType: this.platform.Characteristic.LockControlPoint,
-        getValue: (data) => () => {
-          this.platform.log.debug(`${this.accessory.displayName} GET LockControlPoint: ${data}`);
-          return '';
-        },
         setValue: (value) => () => {
           this.platform.log.debug(`${this.accessory.displayName} SET LockControlPoint: ${value}`);
         },

--- a/src/plugin/platform.ts
+++ b/src/plugin/platform.ts
@@ -79,17 +79,18 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
     const plugin = require('../package.json');
 
     const mainLogObj = {
+      name: (this.config.enableDetailedLogging) ? `[EufySecurity-${plugin.version}]` : '[EufySecurity]',
       prettyLogTemplate: (this.config.enableDetailedLogging)
         // eslint-disable-next-line max-len
-        ? `[{{mm}}/{{dd}}/{{yyyy}} {{hh}}:{{MM}}:{{ss}}]\t[EufySecurity-${plugin.version}]\t{{logLevelName}}\t[{{fileNameWithLine}}{{name}}]\t`
-        : `[{{mm}}/{{dd}}/{{yyyy}} {{hh}}:{{MM}}:{{ss}}]\t[EufySecurity-${plugin.version}]\t{{logLevelName}}\t`,
+        ? '[{{mm}}/{{dd}}/{{yyyy}} {{hh}}:{{MM}}:{{ss}}]\t{{name}}\t{{logLevelName}}\t[{{fileNameWithLine}}{{name}}]\t'
+        : '[{{mm}}/{{dd}}/{{yyyy}}, {{hh}}:{{MM}}:{{ss}}]\t{{name}}\t{{logLevelName}}\t',
       prettyErrorTemplate: '\n{{errorName}} {{errorMessage}}\nerror stack:\n{{errorStack}}',
       prettyErrorStackTemplate: '  • {{fileName}}\t{{method}}\n\t{{fileNameWithLine}}',
       prettyErrorParentNamesSeparator: ':',
       prettyErrorLoggerNameDelimiter: '\t',
       stylePrettyLogs: true,
       minLevel: (this.config.enableDetailedLogging) ? 2 : 3,
-      // prettyLogTimeZone: 'UTC',
+      prettyLogTimeZone: 'local' as 'local' | 'local',
       prettyLogStyles: {
         logLevelName: {
           '*': ['bold', 'black', 'bgWhiteBright', 'dim'],
@@ -101,9 +102,9 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
           ERROR: ['bold', 'red'],
           FATAL: ['bold', 'redBright'],
         },
-        dateIsoStr: 'white',
+        dateIsoStr: 'gray',
         filePathWithLine: 'white',
-        name: ['white', 'bold'],
+        name: 'green',
         nameWithDelimiterPrefix: ['white', 'bold'],
         nameWithDelimiterSuffix: ['white', 'bold'],
         errorName: ['bold', 'bgRedBright', 'whiteBright'],
@@ -341,9 +342,9 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
     };
 
     // Delay execution to allow for property initialization
-    // Required for lock setup, among other things
+    // Station device must be initialized before device
     setTimeout(() => {
-      this.log.info(`${deviceContainer.deviceIdentifier.displayName} pre-caching: done`);
+      this.log.debug(`${deviceContainer.deviceIdentifier.displayName} pre-caching complete`);
       this.processAccessory(deviceContainer);
     }, 5 * 1000); // 5 seconds
   }
@@ -374,9 +375,9 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
     // Delay execution to allow for property initialization
     // Required for lock setup, among other things
     setTimeout(() => {
-      this.log.info(`${deviceContainer.deviceIdentifier.displayName} pre-caching complete`);
+      this.log.debug(`${deviceContainer.deviceIdentifier.displayName} pre-caching complete`);
       this.processAccessory(deviceContainer);
-    }, 6 * 1000); // 6 seconds
+    }, 7 * 1000); // 7 seconds
   }
 
   private processAccessory(deviceContainer: DeviceContainer) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -36,15 +36,16 @@ class UiServer extends HomebridgePluginUiServer {
     const plugin = require('../package.json');
 
     const mainLogObj = {
+      name: `[EufySecurity-${plugin.version}]`,
       // eslint-disable-next-line max-len
-      prettyLogTemplate: `[{{mm}}/{{dd}}/{{yyyy}} {{hh}}:{{MM}}:{{ss}}]\t[EufySecurity-${plugin.version}]\t{{logLevelName}}\t[{{fileNameWithLine}}{{name}}]\t`,
+      prettyLogTemplate: '[{{mm}}/{{dd}}/{{yyyy}} {{hh}}:{{MM}}:{{ss}}]\t{{name}}\t{{logLevelName}}\t[{{fileNameWithLine}}{{name}}]\t',
       prettyErrorTemplate: '\n{{errorName}} {{errorMessage}}\nerror stack:\n{{errorStack}}',
       prettyErrorStackTemplate: '  • {{fileName}}\t{{method}}\n\t{{fileNameWithLine}}',
       prettyErrorParentNamesSeparator: ':',
       prettyErrorLoggerNameDelimiter: '\t',
       stylePrettyLogs: true,
       minLevel: 2,
-      // prettyLogTimeZone: 'UTC',
+      prettyLogTimeZone: 'local' as 'local' | 'local',
       prettyLogStyles: {
         logLevelName: {
           '*': ['bold', 'black', 'bgWhiteBright', 'dim'],
@@ -56,9 +57,9 @@ class UiServer extends HomebridgePluginUiServer {
           ERROR: ['bold', 'red'],
           FATAL: ['bold', 'redBright'],
         },
-        dateIsoStr: 'white',
+        dateIsoStr: 'gray',
         filePathWithLine: 'white',
-        name: ['white', 'bold'],
+        name: 'green',
         nameWithDelimiterPrefix: ['white', 'bold'],
         nameWithDelimiterSuffix: ['white', 'bold'],
         errorName: ['bold', 'bgRedBright', 'whiteBright'],


### PR DESCRIPTION
#### Added
- New approach to handling `propertyName` in `CameraAccessory.ts` for more flexibility.

#### Updated
- Improved logging formats across `BaseAccessory.ts`, `platform.ts`, and `server.ts`.
- Fine-tuned execution delays in `BaseAccessory.ts`, `platform.ts`, and `server.ts` for better performance.
- `BaseAccessory.ts` to make `getValue` optional, allowing for more versatile accessory handling.
  
#### Fixed
- Switch-light issue in `CameraAccessory.ts`.

#### Removed
  - `LockControlPoint` getter because it is not requested by Apple HomeKit Framework.

#### Credits
 - @cixio on PR #416 for notice me the miss, I've used the opportunity to refactor it instead of using switch declaration