### PR TITLE
Update CameraAccessory.ts

### DIFF
--- a/src/plugin/accessories/CameraAccessory.ts
+++ b/src/plugin/accessories/CameraAccessory.ts
@@ -409,7 +409,7 @@ export class CameraAccessory extends DeviceAccessory {
       }
       characteristic.updateValue(this.platform.Characteristic.ProgrammableSwitchEvent.SINGLE_PRESS);
       // Set a new timeout for muting subsequent notifications
-      this.notificationTimeout = setTimeout(() => { }, 3000);
+      this.notificationTimeout = setTimeout(() => { this.notificationTimeout = null; }, 15000);
     }
   }
 


### PR DESCRIPTION
By editing line 412 ; this should solve an already existing issue 

[Bug]:T8210: No 2nd Ring notification at Homekit - restart needed . #463

This solution proposed by other user but i want to test