### PR TITLE
Add ability to disable switch for camera light

### DIFF
--- a/src/configui/app/config-options/camera-buttons/camera-buttons.component.html
+++ b/src/configui/app/config-options/camera-buttons/camera-buttons.component.html
@@ -20,6 +20,16 @@
 
   </div>
 
+  <div class="d-flex justify-content-between align-items-center mb-2">
+    <span>Display HomeKit switch to switch light on/off</span>
+
+    <div class="form-check form-switch">
+      <input class="form-check-input" type="checkbox" role="switch" [(ngModel)]="enableLightButton"
+             id="flexSwitchCheckDefault" (change)="update()">
+    </div>
+
+  </div>
+
   <div class="d-flex justify-content-between align-items-center mb-2" *ngIf="showIndoorChimeButtonSetting">
     <span>Display HomeKit button to turn indoor chime on/off</span>
 

--- a/src/configui/app/config-options/camera-buttons/camera-buttons.component.ts
+++ b/src/configui/app/config-options/camera-buttons/camera-buttons.component.ts
@@ -8,6 +8,7 @@ import { DEFAULT_CAMERACONFIG_VALUES } from '../../util/default-config-values';
 interface UpdatedConfig {
   enableButton: boolean;
   motionButton: boolean;
+  lightButton: boolean;
   indoorChimeButton?: boolean;
 }
 
@@ -29,6 +30,7 @@ export class CameraButtonsComponent extends ConfigOptionsInterpreter implements 
 
   enableCameraButton = true;
   enableMotionButton = true;
+  enableLightButton = true;
   showIndoorChimeButtonSetting = false;
   indoorChimeButton = DEFAULT_CAMERACONFIG_VALUES.indoorChimeButton;
 
@@ -47,6 +49,10 @@ export class CameraButtonsComponent extends ConfigOptionsInterpreter implements 
       this.enableMotionButton = config.motionButton;
     }
 
+    if ('lightButton' in config) {
+      this.enableLightButton = config.lightButton;
+    }
+
     if ('indoorChimeButton' in config) {
       this.indoorChimeButton = config.indoorChimeButton;
     }
@@ -56,6 +62,7 @@ export class CameraButtonsComponent extends ConfigOptionsInterpreter implements 
     const updated: UpdatedConfig = {
       enableButton: this.enableCameraButton,
       motionButton: this.enableMotionButton,
+      lightButton: this.enableLightButton,
     };
 
     if (this.showIndoorChimeButtonSetting) {

--- a/src/plugin/accessories/CameraAccessory.ts
+++ b/src/plugin/accessories/CameraAccessory.ts
@@ -4,7 +4,7 @@ import { EufySecurityPlatform } from '../platform';
 import { DeviceAccessory } from './Device';
 
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore  
+// @ts-ignore
 import { Camera, Device, DeviceEvents, PropertyName, CommandName } from 'eufy-security-client';
 import { StreamingDelegate } from '../controller/streamingDelegate';
 
@@ -134,7 +134,7 @@ export class CameraAccessory extends DeviceAccessory {
   }
 
   private async setupLightButton() {
-    this.setupButtonService('Light', true, PropertyName.DeviceLight, 'lightbulb');
+    this.setupButtonService('Light', this.cameraConfig.lightButton, PropertyName.DeviceLight, 'lightbulb');
   }
 
   private async setupChimeButton() {
@@ -154,6 +154,7 @@ export class CameraAccessory extends DeviceAccessory {
     config.name = this.accessory.displayName;
     config.enableButton = config.enableButton ??= true;
     config.motionButton = config.motionButton ??= true;
+    config.lightButton = config.lightButton ??= true;
     config.rtsp = config.rtsp ??= false;
     config.forcerefreshsnap = config.forcerefreshsnap ??= false;
     config.videoConfig = config.videoConfig ??= {};
@@ -344,7 +345,7 @@ export class CameraAccessory extends DeviceAccessory {
         return value === 1;
       }
 
-      // Override for PropertyName.DeviceEnabled when enabled button is fired and 
+      // Override for PropertyName.DeviceEnabled when enabled button is fired and
       if (
         propertyName === PropertyName.DeviceEnabled &&
         Date.now() - this.cameraStatus.timestamp <= 60000

--- a/src/plugin/utils/configTypes.ts
+++ b/src/plugin/utils/configTypes.ts
@@ -12,6 +12,7 @@ export type CameraConfig = {
   videoConfig?: VideoConfig;
   enableButton: boolean;
   motionButton: boolean;
+  lightButton: boolean;
   rtsp: boolean;
   videoConfigEna: boolean;
   enableCamera: boolean;


### PR DESCRIPTION
Hello! Thank you for the awesome project! 🎉 

This PR adds the ability to disable the homekit switch to turn on an off a cameras light. I don't use this functionality, so I wanted a way in the configuration to disable this switch. 

Thanks! 