### PR TITLE
fix: out of complience error when door lock battery is not reported

### DIFF
--- a/src/plugin/accessories/Device.ts
+++ b/src/plugin/accessories/Device.ts
@@ -59,6 +59,7 @@ export abstract class DeviceAccessory extends BaseAccessory {
         characteristicType: CHAR.BatteryLevel,
         propertyName: PropertyName.DeviceBattery,
         onSimpleValue: null,
+        fallback: 100
       },
       {
         property: 'batteryLow',
@@ -79,7 +80,7 @@ export abstract class DeviceAccessory extends BaseAccessory {
         this.registerCharacteristic({
           serviceType: serviceType,
           characteristicType: propertyConfig.characteristicType,
-          getValue: () => this.device.getPropertyValue(propertyConfig.propertyName),
+          getValue: () => this.device.getPropertyValue(propertyConfig.propertyName) || propertyConfig.fallback,
           onSimpleValue: propertyConfig.onSimpleValue,
         });
       }


### PR DESCRIPTION
- Device type 50 (LOCK_BLE) has an optional battery property which may or may not be reported
- In the case that the battery is undefined, the entire plugin causes an "Out of Compliance" error in homekit.
- To fix, I had to add a fallback value of 100% (don't know what the battery level is so just assume it's good and let the end user handle it).