### PR TITLE
[Bug]: Inconsistencies in Applying Display Settings for Enabled, Motion, and Light Buttons  Fixes #543

### DIFF
--- a/src/configui/app/config-options/camera-buttons/camera-buttons.component.ts
+++ b/src/configui/app/config-options/camera-buttons/camera-buttons.component.ts
@@ -10,6 +10,7 @@ import { NgFor } from '@angular/common';
 
 interface ButtonConfig {
   name: string;
+  button: string;
   description: string;
   value: boolean;
   propertyName: keyof L_Device;
@@ -25,10 +26,10 @@ export class CameraButtonsComponent extends ConfigOptionsInterpreter implements 
   @Input() device?: L_Device;
 
   buttonConfigs: ButtonConfig[] = [
-    { name: 'Enable', description: 'camera', value: DEFAULT_CAMERACONFIG_VALUES.enableButton, propertyName: 'DeviceEnabled' },
-    { name: 'Motion', description: 'detection', value: DEFAULT_CAMERACONFIG_VALUES.motionButton, propertyName: 'DeviceMotionDetection' },
-    { name: 'Light', description: 'light', value: DEFAULT_CAMERACONFIG_VALUES.lightButton, propertyName: 'DeviceLight' },
-    { name: 'IndoorChime', description: 'indoor chime', value: DEFAULT_CAMERACONFIG_VALUES.indoorChimeButton!, propertyName: 'DeviceChimeIndoor' },
+    { name: 'Enable', button: 'enableButton', description: 'camera', value: DEFAULT_CAMERACONFIG_VALUES.enableButton, propertyName: 'DeviceEnabled' },
+    { name: 'Motion', button: 'motionButton', description: 'detection', value: DEFAULT_CAMERACONFIG_VALUES.motionButton, propertyName: 'DeviceMotionDetection' },
+    { name: 'Light', button: 'lightButton', description: 'light', value: DEFAULT_CAMERACONFIG_VALUES.lightButton, propertyName: 'DeviceLight' },
+    { name: 'IndoorChime', button: 'indoorChimeButton', description: 'indoor chime', value: DEFAULT_CAMERACONFIG_VALUES.indoorChimeButton!, propertyName: 'DeviceChimeIndoor' },
   ];
 
   constructor(
@@ -47,8 +48,8 @@ export class CameraButtonsComponent extends ConfigOptionsInterpreter implements 
 
     this.buttonConfigs = this.buttonConfigs.filter((buttonConfig) => {
       if (this.device && this.device[buttonConfig.propertyName]) {
-        if (buttonConfig.name in config) {
-          buttonConfig.value = config[buttonConfig.name] ?? buttonConfig.value;
+        if (buttonConfig.button in config) {
+          buttonConfig.value = config[buttonConfig.button] ?? buttonConfig.value;
         }
         return true; // Keep the buttonConfig
       } else {
@@ -60,7 +61,7 @@ export class CameraButtonsComponent extends ConfigOptionsInterpreter implements 
   update(): void {
     const updated: Record<string, boolean> = {};
     this.buttonConfigs.forEach(buttonConfig => {
-      updated[buttonConfig.name.toLowerCase()] = buttonConfig.value;
+      updated[buttonConfig.button] = buttonConfig.value;
     });
 
     this.updateDeviceConfig(updated, this.device!);

--- a/src/configui/app/config-options/enable-hsv/enable-hsv.component.ts
+++ b/src/configui/app/config-options/enable-hsv/enable-hsv.component.ts
@@ -64,14 +64,6 @@ export class EnableHsvComponent extends ConfigOptionsInterpreter implements OnIn
       this.value = config['hsv'];
     }
 
-    if (config && Object.prototype.hasOwnProperty.call(config, 'hsvConfig')) {
-      Object.entries(config['hsvConfig']).forEach(([key, value]) => {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const obj = this as any;
-        obj[key] = value;
-      });
-    }
-
     try {
 
       if (this.device) {
@@ -96,8 +88,8 @@ export class EnableHsvComponent extends ConfigOptionsInterpreter implements OnIn
   }
 
   update() {
-    this.updateConfig({
+    this.updateDeviceConfig({
       hsv: this.value,
-    });
+    }, this.device!);
   }
 }

--- a/src/plugin/controller/recordingDelegate.ts
+++ b/src/plugin/controller/recordingDelegate.ts
@@ -89,14 +89,14 @@ export class RecordingDelegate implements CameraRecordingDelegate {
       const videoParams = await FFmpegParameters.forVideoRecording();
       const audioParams = await FFmpegParameters.forAudioRecording();
 
-      const hsvConfig: VideoConfig = this.cameraConfig.hsvConfig ?? {};
+      const videoConfig: VideoConfig = this.cameraConfig.videoConfig ?? {};
 
       if (this.cameraConfig.videoConfig && this.cameraConfig.videoConfig.videoProcessor) {
-        hsvConfig.videoProcessor = this.cameraConfig.videoConfig.videoProcessor;
+        videoConfig.videoProcessor = this.cameraConfig.videoConfig.videoProcessor;
       }
 
-      videoParams.setupForRecording(hsvConfig, this.configuration!);
-      audioParams.setupForRecording(hsvConfig, this.configuration!);
+      videoParams.setupForRecording(videoConfig, this.configuration!);
+      audioParams.setupForRecording(videoConfig, this.configuration!);
 
       const rtsp = is_rtsp_ready(this.camera, this.cameraConfig);
 

--- a/src/plugin/utils/configTypes.ts
+++ b/src/plugin/utils/configTypes.ts
@@ -24,7 +24,6 @@ export type CameraConfig = {
   talkbackChannels?: number;
   hsv?: boolean;
   hsvRecordingDuration?: number;
-  hsvConfig?: VideoConfig;
   indoorChimeButton?: boolean;
 };
 


### PR DESCRIPTION
## What's news
### Fixed:
- Addressed the persistent display issue where Apple HomeKit buttons for enabled, motion, or light plugins were not adhering to configuration settings. Buttons now correctly reflect configured display preferences, ensuring consistency and accuracy in the user interface.