### PR TITLE
chore: Update Node.js compatibility check

### DIFF
--- a/src/plugin/platform.ts
+++ b/src/plugin/platform.ts
@@ -776,7 +776,7 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
     log.debug('Node version is', nodeVersion);
 
     // Define versions known to break compatibility with RSA_PKCS1_PADDING
-    this.nodeJScompatible = satisfies(nodeVersion, '^18.19.1 || ^20.11.1 || ^21.6.2');
+    this.nodeJScompatible = satisfies(nodeVersion, '>=18.19.1 <19.x || >=20.11.1 <21.x || >=21.6.2 <22');
 
     // Return true if the Node.js version is compatible, false otherwise
     return !this.nodeJScompatible;

--- a/src/server.ts
+++ b/src/server.ts
@@ -109,7 +109,7 @@ class UiServer extends HomebridgePluginUiServer {
    */
   public nodeJSVersion() {
     // Define versions known to break compatibility with RSA_PKCS1_PADDING
-    const nodeJSIncompatible = satisfies(nodeJSversion, '^18.19.1 || ^20.11.1 || ^21.6.2');
+    const nodeJSIncompatible = satisfies(nodeJSversion, '>=18.19.1 <19.x || >=20.11.1 <21.x || >=21.6.2 <22');
     return {
       nodeJSversion: nodeJSversion,
       nodeJSIncompatible: nodeJSIncompatible,


### PR DESCRIPTION
This pull request updates the compatibility check for Node.js versions in the code. Previously, the check used a version range that included versions known to break compatibility with RSA_PKCS1_PADDING. This PR updates the version range to exclude those incompatible versions and ensures that the check is more accurate.

thanks @ivan-garcia-parras