### PR TITLE
Prepare for Homebridge v2 integration

### DIFF
--- a/.github/workflows/publish_release.yml
+++ b/.github/workflows/publish_release.yml
@@ -61,6 +61,7 @@ jobs:
       - run: git config --global user.email '<>'
       - run: npm version ${{ github.event.inputs.version }} --preid=${{ github.event.inputs.preid }} -m "[${{ github.event.inputs.tag }}] %s"
       - run: npm update homebridge-eufy-security
+      - run: npm run prebuild
       - run: git push --force
       - run: git push origin --tags --force
 

--- a/.gitignore
+++ b/.gitignore
@@ -124,8 +124,6 @@ dist
 .history
 .nx/
 
-.github/workflows/
-
 .angular
 
 homebridge-ui/

--- a/src/configui/app/util/default-config-values.ts
+++ b/src/configui/app/util/default-config-values.ts
@@ -3,6 +3,7 @@ import { EufySecurityPlatformConfig } from '../../../plugin/config';
 
 export const DEFAULT_CONFIG_VALUES: EufySecurityPlatformConfig = {
   platform: 'EufySecurity',
+  name: 'EufySecurity',
   username: '',
   password: '',
   deviceName: 'MyPhone',

--- a/src/plugin/accessories/BaseAccessory.ts
+++ b/src/plugin/accessories/BaseAccessory.ts
@@ -4,7 +4,6 @@ import {
   CharacteristicValue,
   Service,
   WithUUID,
-  APIEvent,
 } from 'homebridge';
 import { EufySecurityPlatform } from '../platform';
 import { DeviceType, DeviceEvents, PropertyValue, Device, Station, StationEvents } from 'eufy-security-client';

--- a/src/plugin/accessories/BaseAccessory.ts
+++ b/src/plugin/accessories/BaseAccessory.ts
@@ -89,11 +89,6 @@ export abstract class BaseAccessory extends EventEmitter {
       this.device.on('property changed', this.handlePropertyChange.bind(this));
     }
 
-    this.platform.api.on(APIEvent.SHUTDOWN, async () => {
-      this.log.debug(`Removing Listeners - num:`, this.listeners.length);
-      this.removeAllListeners();
-    });
-
     this.logPropertyKeys();
   }
 

--- a/src/plugin/config.ts
+++ b/src/plugin/config.ts
@@ -31,6 +31,7 @@ export interface EufySecurityPlatformConfig extends PlatformConfig {
 
 export const DEFAULT_CONFIG_VALUES: EufySecurityPlatformConfig = {
   platform: 'EufySecurity',
+  name: 'EufySecurity',
   username: '',
   password: '',
   deviceName: 'MyPhone',

--- a/src/plugin/controller/streamingDelegate.ts
+++ b/src/plugin/controller/streamingDelegate.ts
@@ -1,5 +1,4 @@
 import {
-  APIEvent,
   AudioStreamingCodecType,
   CameraController,
   CameraStreamingDelegate,

--- a/src/plugin/controller/streamingDelegate.ts
+++ b/src/plugin/controller/streamingDelegate.ts
@@ -89,12 +89,6 @@ export class StreamingDelegate implements CameraStreamingDelegate {
       this.localLivestreamManager,
     );
 
-    this.platform.api.on(APIEvent.SHUTDOWN, () => {
-      for (const session in this.ongoingSessions) {
-        this.stopStream(session);
-      }
-      this.localLivestreamManager.stopLocalLiveStream();
-    });
   }
 
   public setController(controller: CameraController) {

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,6 +1,6 @@
 import { API } from 'homebridge';
 
-import { PLATFORM_NAME } from './settings';
+import { PLATFORM_NAME, PLUGIN_NAME } from './settings';
 import { EufySecurityPlatform } from './platform';
 import { setHap } from './utils/utils';
 
@@ -9,5 +9,5 @@ import { setHap } from './utils/utils';
  */
 export = (api: API) => {
   setHap(api.hap);
-  api.registerPlatform(PLATFORM_NAME, EufySecurityPlatform);
+  api.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, EufySecurityPlatform);
 };

--- a/src/plugin/platform.ts
+++ b/src/plugin/platform.ts
@@ -4,7 +4,6 @@ import {
   DynamicPlatformPlugin,
   Logger,
   PlatformAccessory,
-  PlatformConfig,
   APIEvent,
 } from 'homebridge';
 

--- a/src/plugin/platform.ts
+++ b/src/plugin/platform.ts
@@ -58,7 +58,6 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
 
   // this is used to track restored cached accessories
   public readonly accessories: PlatformAccessory[] = [];
-  public config: EufySecurityPlatformConfig = {} as EufySecurityPlatformConfig;
 
   private already_shutdown: boolean = false;
 
@@ -73,7 +72,7 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
 
   constructor(
     hblog: Logger,
-    config: PlatformConfig,
+    public config: EufySecurityPlatformConfig,
     public readonly api: API,
   ) {
 


### PR DESCRIPTION
This pull request includes several updates to prepare the plugin for integration with Homebridge v2:

1. Updated `.github/workflows/publish_release.yml`:
   - Added `npm run prebuild` step to ensure proper build process for v2 compatibility

2. Modified `.gitignore`:
   - Removed `.github/workflows/` from ignored files to ensure workflow files are properly tracked

3. Updated default config values:
   - Added `name: 'EufySecurity'` to default configuration in both:
     - `src/configui/app/util/default-config-values.ts`
     - `src/plugin/config.ts`
   - This change ensures compliance with Homebridge v2 config structure requirements

4. Removed deprecated event listeners:
   - Removed `APIEvent.SHUTDOWN` listener in `BaseAccessory`
   - Removed `APIEvent.SHUTDOWN` listener in `StreamingDelegate`
   - These changes align with Homebridge v2's updated lifecycle management

5. Updated plugin registration in `src/plugin/index.ts`:
   - Changed from `api.registerPlatform(PLATFORM_NAME, EufySecurityPlatform)` to `api.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, EufySecurityPlatform)`
   - This update ensures proper plugin registration format for Homebridge v2

6. Refactored `platform.ts`:
   - Updated `config` property type and initialization to match Homebridge v2 expectations

These changes collectively prepare the plugin for seamless integration with Homebridge v2, ensuring compatibility with the new version's architecture and requirements. The updates address configuration structure, event handling, and plugin registration to align with Homebridge v2 standards.