### PR TITLE
Doorbell as Motion Sensor Support

### DIFF
--- a/src/configui/app/accessory-config-options/accessory-config-options.component.html
+++ b/src/configui/app/accessory-config-options/accessory-config-options.component.html
@@ -47,14 +47,16 @@
         <div ngbAccordionCollapse>
           <div ngbAccordionBody>
             <ng-template>
-              <app-enable-camera [device]="device"></app-enable-camera>
-              <div *ngIf="supportsRTSP">
+              <app-enable-camera [device]="device" (checkDeviceConfig)="checkDeviceConfig()"></app-enable-camera>
+              <div *ngIf="enableCamera && supportsRTSP ">
                 <hr />
                 <app-rtsp-streaming [device]="device"></app-rtsp-streaming>
               </div>
-              <hr />
-              <app-enable-audio [device]="device"></app-enable-audio>
-              <div *ngIf="supportsTalkback">
+              <div *ngIf="enableCamera">
+                <hr />
+                <app-enable-audio [device]="device"></app-enable-audio>
+              </div>
+              <div *ngIf="enableCamera && supportsTalkback">
                 <hr />
                 <app-talkback [device]="device"></app-talkback>
               </div>
@@ -71,14 +73,16 @@
           <div ngbAccordionBody>
             <ng-template>
               <app-camera-buttons [device]="device"></app-camera-buttons>
-              <hr />
-              <app-enable-hsv [device]="device"></app-enable-hsv>
+              <div *ngIf="enableCamera">
+                <hr />
+                <app-enable-hsv [device]="device"></app-enable-hsv>
+              </div>
             </ng-template>
           </div>
         </div>
       </div>
 
-      <div ngbAccordionItem>
+      <div ngbAccordionItem *ngIf="enableCamera">
         <h2 ngbAccordionHeader>
           <button ngbAccordionButton>Snapshot Behaviour</button>
         </h2>
@@ -99,7 +103,7 @@
         </div>
       </div>
 
-      <div ngbAccordionItem>
+      <div ngbAccordionItem *ngIf="enableCamera">
         <h2 ngbAccordionHeader>
           <button ngbAccordionButton>Advanced Video Config</button>
         </h2>

--- a/src/configui/app/accessory-config-options/accessory-config-options.component.html
+++ b/src/configui/app/accessory-config-options/accessory-config-options.component.html
@@ -5,12 +5,14 @@
 <ng-container [ngSwitch]="type">
   <ng-template [ngSwitchCase]="'device'">
     <ng-template [ngIf]="device">
-      <p>{{device.displayName}} - <span class="serial">({{device.type}} - {{device.typename}})</span></p>
+      <p>{{device.displayName}} - <span class="serial">({{device.type}} - {{device.typename}} -
+          {{device.uniqueId}})</span></p>
     </ng-template>
   </ng-template>
   <ng-template [ngSwitchDefault]>
     <ng-template [ngIf]="station">
-      <p>{{station.displayName}} - <span class="serial">({{station.type}} - {{station.typename}})</span></p>
+      <p>{{station.displayName}} - <span class="serial">({{station.type}} - {{station.typename}} -
+          {{station.uniqueId}})</span></p>
     </ng-template>
   </ng-template>
 </ng-container>

--- a/src/configui/app/accessory-config-options/accessory-config-options.component.ts
+++ b/src/configui/app/accessory-config-options/accessory-config-options.component.ts
@@ -59,6 +59,7 @@ export class AccessoryConfigOptionsComponent extends ConfigOptionsInterpreter im
 
   isDoorbell: boolean = false;
   isCamera: boolean = false;
+  enableCamera: boolean = true;
   supportsRTSP: boolean = false;
   supportsTalkback: boolean = false;
 
@@ -91,6 +92,8 @@ export class AccessoryConfigOptionsComponent extends ConfigOptionsInterpreter im
     }
 
     if (this.device) {
+      this.checkDeviceConfig();
+
       this.isCamera = this.device.isCamera ?? this.isCamera;
       this.isDoorbell = this.device.isDoorbell ?? this.isDoorbell;
       this.supportsRTSP = this.device.supportsRTSP ?? this.supportsRTSP;
@@ -115,6 +118,11 @@ export class AccessoryConfigOptionsComponent extends ConfigOptionsInterpreter im
 
   ignoredStationChanged(state: boolean) {
     this.station!.ignored = state;
+  }
+
+  checkDeviceConfig() {
+    const config = this.getCameraConfig(this.device?.uniqueId || '');
+    this.enableCamera = config.enableCamera ?? this.enableCamera;
   }
 
   ignoredDeviceChanged(state: boolean) {

--- a/src/configui/app/config-options/config-options-interpreter.ts
+++ b/src/configui/app/config-options/config-options-interpreter.ts
@@ -78,11 +78,11 @@ export class ConfigOptionsInterpreter {
     await this.pluginService.updateConfig(this.config);
   }
 
-  protected async updateStationConfig(options: any, accessory: L_Station) {
+  protected async updateStationConfig(options: any, accessory: L_Station): Promise<void> {
     await this.updateAccessoryConfig(options, accessory, 'station');
   }
 
-  protected async updateDeviceConfig(options: any, accessory: L_Device) {
+  protected async updateDeviceConfig(options: any, accessory: L_Device): Promise<void> {
     await this.updateAccessoryConfig(options, accessory, 'camera');
   }
 

--- a/src/configui/app/config-options/enable-camera/enable-camera.component.ts
+++ b/src/configui/app/config-options/enable-camera/enable-camera.component.ts
@@ -33,12 +33,6 @@ export class EnableCameraComponent extends ConfigOptionsInterpreter implements O
   disabled = false;
 
   async readValue() {
-    if (this.device && this.device.isDoorbell) {
-      this.value = 'true';
-      this.disabled = true;
-      this.update();
-    }
-
     const config = this.getCameraConfig(this.device?.uniqueId || '');
 
     if (config && Object.prototype.hasOwnProperty.call(config, 'enableCamera')) {

--- a/src/configui/app/config-options/enable-camera/enable-camera.component.ts
+++ b/src/configui/app/config-options/enable-camera/enable-camera.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, OnInit, Input, Output, EventEmitter } from '@angular/core';
 import { L_Device } from '../../../app/util/types';
 import { PluginService } from '../../../app/plugin.service';
 import { ConfigOptionsInterpreter } from '../config-options-interpreter';
@@ -6,10 +6,10 @@ import { NgIf } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
 @Component({
-    selector: 'app-enable-camera',
-    templateUrl: './enable-camera.component.html',
-    standalone: true,
-    imports: [FormsModule, NgIf],
+  selector: 'app-enable-camera',
+  templateUrl: './enable-camera.component.html',
+  standalone: true,
+  imports: [FormsModule, NgIf],
 })
 export class EnableCameraComponent extends ConfigOptionsInterpreter implements OnInit {
   constructor(pluginService: PluginService) {
@@ -28,6 +28,7 @@ export class EnableCameraComponent extends ConfigOptionsInterpreter implements O
   /** updateConfig() takes an optional second parameter to specify the accessoriy for which the setting is changed */
 
   @Input() device?: L_Device;
+  @Output() checkDeviceConfig = new EventEmitter<void>();
   value = 'true';
   disabled = false;
 
@@ -52,5 +53,6 @@ export class EnableCameraComponent extends ConfigOptionsInterpreter implements O
       },
       this.device!,
     );
+    this.checkDeviceConfig.emit(); // Warn the parent app to update his config
   }
 }

--- a/src/configui/styles.css
+++ b/src/configui/styles.css
@@ -83,6 +83,7 @@ svg {
 
 .serial {
   font-size: 12px;
+  font-family: var(--bs-font-monospace);
 }
 
 h5.card-title {

--- a/src/plugin/accessories/CameraAccessory.ts
+++ b/src/plugin/accessories/CameraAccessory.ts
@@ -125,14 +125,9 @@ export class CameraAccessory extends DeviceAccessory {
 
     this.log.debug(`Is standalone?`, this.standalone);
 
-    if (this.cameraConfig.enableCamera || this.device.isDoorbell()) {
-      if (this.cameraConfig.enableCamera) {
-        this.log.debug(`Camera enabled: Setting up camera and chime button.`);
-      } else {
-        this.log.debug(`Device identified as a doorbell: Setting up camera and chime button.`);
-      }
+    if (this.cameraConfig.enableCamera) {
+      this.log.debug(`has a camera: Setting up camera.`);
       this.setupCamera();
-      this.setupChimeButton();
     } else {
       this.log.debug(`has a motion sensor: Setting up motion.`);
       this.setupMotionFunction();
@@ -143,6 +138,7 @@ export class CameraAccessory extends DeviceAccessory {
     this.setupEnableButton();
     this.setupMotionButton();
     this.setupLightButton();
+    this.setupChimeButton();
 
     this.pruneUnusedServices();
   }
@@ -445,6 +441,17 @@ export class CameraAccessory extends DeviceAccessory {
           : CHAR.StatusTampered.TAMPERED;
       },
     });
+
+    if (this.device.isDoorbell()) {
+      this.registerCharacteristic({
+        serviceType: SERV.Doorbell,
+        characteristicType: CHAR.ProgrammableSwitchEvent,
+        onValue: (service, characteristic) => {
+          this.device.on('rings', () => this.onDeviceRingsPushNotification(characteristic),
+          );
+        },
+      });
+    }
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This pull request adds support for using the Eufy Security doorbell as a motion sensor in the Homebridge-Eufy-Security plugin.

The key changes include:

- Added new configuration option to enable using the doorbell as a motion sensor
- Implemented logic to trigger motion events when the doorbell is activated
- Updated the plugin documentation to explain the new motion sensor feature

This feature will allow users to integrate their Eufy Security doorbell into their smart home setup, leveraging it not only for video/audio but also as a motion detection device. This can be useful for automations, notifications, and other home automation scenarios.