### PR TITLE
ban by eufy - Can't log back in after updating to 4.0.1

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -30,7 +30,7 @@ class UiServer extends HomebridgePluginUiServer {
     trustedDeviceName: 'My Phone',
     persistentDir: this.storagePath,
     p2pConnectionSetup: 0,
-    pollingIntervalMinutes: 0,
+    pollingIntervalMinutes: 99,
     eventDurationSeconds: 10,
     acceptInvitations: true,
   } as EufySecurityConfig;
@@ -167,6 +167,11 @@ class UiServer extends HomebridgePluginUiServer {
         this.eufyClient = await EufySecurity.initialize(this.config, this.tsLog);
         this.eufyClient?.on('station added', await this.addStation.bind(this));
         this.eufyClient?.on('device added', await this.addDevice.bind(this));
+        // Close connection after 40 seconds enough time to get all devices
+        setTimeout(() => {
+          this.eufyClient?.removeAllListeners();
+          this.eufyClient?.close();
+        }, 40 * 1000);
       } catch (err) {
         this.log.error(err);
       }


### PR DESCRIPTION
Optimize initial device discovery for Eufy Security plugin

- Set polling interval to 99 minutes to reduce API calls during setup
- Add 40-second timeout to close Eufy client connection after device discovery
- Ensure client listeners are removed after initial setup

These changes are designed to run once during the initial plugin configuration, allowing for efficient device discovery while preventing unnecessary ongoing connections and API calls. This should improve resource usage and avoid potential rate-limiting issues during the setup process.