### PR TITLE
feat: add support for Node.js 22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,6 @@
         "ffmpeg-for-homebridge": "2.1.7",
         "fs-extra": "^11.3.0",
         "rotating-file-stream": "^3.2.6",
-        "semver": "^7.7.1",
         "tslog": "^4.9.3",
         "zip-lib": "^1.1.2"
       },
@@ -69,7 +68,7 @@
       },
       "engines": {
         "homebridge": "^1.8.0 || ^2.0.0-beta.0",
-        "node": "20.10.0||^20"
+        "node": "^22"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -15485,6 +15484,7 @@
       "version": "7.7.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
       "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "dev": true,
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/homebridge-eufy-security/plugin/issues"
   },
   "engines": {
-    "node": "20.10.0||^20",
+    "node": "^22",
     "homebridge": "^1.8.0 || ^2.0.0-beta.0"
   },
   "main": "dist/index.js",
@@ -51,7 +51,6 @@
     "ffmpeg-for-homebridge": "2.1.7",
     "fs-extra": "^11.3.0",
     "rotating-file-stream": "^3.2.6",
-    "semver": "^7.7.1",
     "tslog": "^4.9.3",
     "zip-lib": "^1.1.2"
   },

--- a/src/configui/app/login/login.component.html
+++ b/src/configui/app/login/login.component.html
@@ -5,25 +5,6 @@
     eufy cloud here.</i>
 </ng-template>
 
-<ng-template #popInfoNodeJS>
-  <p>You can override this warning by configuring a special parameter in the global configuration after login.
-    To resolve this issue, please consider downgrading to a compatible version using a command similar to: sudo
-    hb-service update-node 20.11.0.</p>
-
-  <p> Versions known to cause compatibility issues with this plugin include those within the following ranges: </p>
-  <ul>
-    <li>Node.js 18.x.x (starting from 18.19.1 up to the next major release)</li>
-    <li>Node.js 20.x.x (starting from 20.11.1 up to the next major release)</li>
-    <li>Node.js 21.x.x (starting from 21.6.2 up to the next major release)</li>
-  </ul>
-
-  <p> For instructions on how to upgrade or downgrade Node.js, please refer to:
-    https://github.com/homebridge/homebridge/wiki/How-To-Update-Node.js
-    For more information on the security vulnerability affecting Node.js, visit:
-    https://nodejs.org/en/blog/vulnerability/february-2024-security-releases#nodejs-is-vulnerable-to-the-marvin-attack-timing-variant-of-the-bleichenbacher-attack-against-pkcs1-v15-padding-cve-2023-46809---medium
-  </p>
-</ng-template>
-
 <!-- Login failed alert -->
 <p class="col-11 col-sm-7" *ngIf="loginFailed">
   <ngb-alert [dismissible]="true" type="danger" (closed)="resetLoginFailed()">
@@ -35,18 +16,6 @@
 
 <!-- Login form start -->
 <div *ngIf="loginStep === 0" class="text-right">
-  <div *ngIf="nodeJSIncompatible" class="alert alert-danger d-flex align-items-center text-left" role="alert">
-    <lucide-angular name="info" class="m-2"></lucide-angular>
-    <div>
-      Error: Your current Node.js version {{ nodeJSversion }} is incompatible with the
-      RSA_PKCS1_PADDING used by the plugin. If you run the plugin with an incompatible version of Node.js,
-      livestream functionality will be disrupted.
-      <u role="button" popoverTitle="Please downgrade your NodeJS version" [autoClose]="'outside'"
-        [ngbPopover]="popInfoNodeJS">
-        Tell me why...
-      </u>
-    </div>
-  </div>
   <div class="alert alert-warning d-flex align-items-center text-left" role="alert">
     <lucide-angular name="info" class="m-2"></lucide-angular>
     <div>

--- a/src/configui/app/login/login.component.ts
+++ b/src/configui/app/login/login.component.ts
@@ -6,7 +6,7 @@ import { LoginService } from '../login.service';
 
 import { COUNTRIES } from '../countries';
 import { FormsModule } from '@angular/forms';
-import { NgbAlert, NgbPopover, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
+import { NgbAlert, NgbTooltip } from '@ng-bootstrap/ng-bootstrap';
 import { NgIf, NgFor } from '@angular/common';
 import { LucideAngularModule } from 'lucide-angular';
 
@@ -24,7 +24,6 @@ enum LoginStep {
   imports: [
     NgIf,
     NgbAlert,
-    NgbPopover,
     FormsModule,
     NgbTooltip,
     NgFor,
@@ -53,9 +52,6 @@ export class LoginComponent implements OnInit {
 
   firstLoginAssumed = false;
 
-  nodeJSIncompatible: boolean = true;
-  nodeJSversion: string = '1.1.1';
-
   emailIsValid = true;
   passwordIsValid = true;
   otpIsValid = true;
@@ -64,12 +60,6 @@ export class LoginComponent implements OnInit {
   constructor(private loginService: LoginService, private routerService: Router) { }
 
   async ngOnInit(): Promise<void> {
-    const r = await window.homebridge.request('/nodeJSVersion');
-    this.nodeJSversion = r.nodeJSversion;
-    this.nodeJSIncompatible = r.nodeJSIncompatible;
-
-    console.log('r: ', r);
-
     this.getCredentials();
     this.fillCountryArray();
   }

--- a/src/plugin/controller/LocalLivestreamManager.ts
+++ b/src/plugin/controller/LocalLivestreamManager.ts
@@ -81,12 +81,6 @@ export class LocalLivestreamManager extends EventEmitter {
         () => {
           this.stopLocalLiveStream();
           this.livestreamIsStarting = false;
-          if (!this.camera.platform.nodeJScompatible) {
-            this.log.error(`
-              Error: Your current Node.js version is incompatible with the RSA_PKCS1_PADDING used by the plugin.
-              If you run the plugin with an incompatible version of Node.js, livestream functionality will be disrupted.
-            `);
-          }
           reject('No livestream emited... Something wrong between HB and your cam!');
         },
         15 * 1000 // After 10sec Apple HK will disconnect so all of this for nothing...

--- a/src/plugin/controller/LocalLivestreamManager.ts
+++ b/src/plugin/controller/LocalLivestreamManager.ts
@@ -79,6 +79,7 @@ export class LocalLivestreamManager extends EventEmitter {
       // Hard stop
       const hardStop = setTimeout(
         () => {
+          this.log.error('Livestream timeout: No livestream emitted within the expected timeframe.');
           this.stopLocalLiveStream();
           this.livestreamIsStarting = false;
           reject('No livestream emited... Something wrong between HB and your cam!');

--- a/src/plugin/platform.ts
+++ b/src/plugin/platform.ts
@@ -8,7 +8,6 @@ import {
 } from 'homebridge';
 
 import { version } from 'process';
-import { clean, satisfies } from 'semver';
 
 import { DEVICE_INIT_DELAY, PLATFORM_NAME, PLUGIN_NAME, STATION_INIT_DELAY } from './settings';
 
@@ -66,8 +65,6 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
   private cleanCachedAccessoriesTimeout?: NodeJS.Timeout;
 
   private _hostSystem: string = '';
-
-  public nodeJScompatible: boolean = false;
 
   constructor(
     hblog: Logger,
@@ -313,29 +310,6 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
     log.debug('plugin data store:', this.eufyPath);
     log.debug('OS is', this.hostSystem);
     log.debug('Using bropats @homebridge-eufy-security/eufy-security-client library in version ', libVersion);
-
-    if (!this.checkNodeJSVersionCompatibility()) {
-      log.error(`
-      ***************************
-      ****** ERROR MESSAGE ******
-      ***************************
-      Error: Your current Node.js version (${version}) is incompatible with the RSA_PKCS1_PADDING used by the plugin.
-      If you run the plugin with an incompatible version of Node.js, livestream functionality will be disrupted. 
-
-      You can override this warning by configuring a special parameter in the global configuration.
-      To resolve this issue, please consider downgrading to a compatible version using a command similar to: sudo hb-service update-node 20.11.0.
-
-      Versions known to cause compatibility issues with this plugin include those within the following ranges:
-      - Node.js 18.x.x (starting from 18.19.1 up to the next major release)
-      - Node.js 20.x.x (starting from 20.11.1 up to the next major release)
-      - Node.js 21.x.x (starting from 21.6.2 up to the next major release)
-
-      For instructions on how to upgrade or downgrade Node.js, please refer to: https://github.com/homebridge/homebridge/wiki/How-To-Update-Node.js
-      For more information on the security vulnerability affecting Node.js, visit: 
-      https://nodejs.org/en/blog/vulnerability/february-2024-security-releases#nodejs-is-vulnerable-to-the-marvin-attack-timing-variant-of-the-bleichenbacher-attack-against-pkcs1-v15-padding-cve-2023-46809---medium
-      ***************************        
-      `);
-    }
 
     // Log the final configuration object for debugging purposes
     log.debug('The config is:', this.config);
@@ -753,33 +727,6 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
       throw new Error('The keypad needs to be taken out because it serves no purpose. You can ignore this message.');
     }
 
-  }
-
-  /**
-   * Checks compatibility of the current Node.js version with Livestream functionality.
-   * @returns {boolean} Returns true if the Node.js version is compatible, false otherwise.
-   */
-  private checkNodeJSVersionCompatibility(): boolean {
-
-    // Obtain the cleaned version of Node.js
-    const nodeVersion = clean(version);
-
-    // If version cannot be determined, assume compatibility
-    if (!nodeVersion) {
-      return true;
-    }
-
-    // Log the Node.js version for debugging purposes
-    log.debug('Node version is', nodeVersion);
-
-    // Define versions known to break compatibility with RSA_PKCS1_PADDING
-    this.nodeJScompatible = !satisfies(nodeVersion, '>=18.19.1 <19.x || >=20.11.1 <21.x || >=21.6.2 <22');
-
-    // Log the Node.js version for debugging purposes
-    log.debug('Node version is compatible', this.nodeJScompatible);
-
-    // Return true if the Node.js version is compatible, false otherwise
-    return this.nodeJScompatible;
   }
 
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,8 +6,6 @@ import { createStream } from 'rotating-file-stream';
 import { Zip } from 'zip-lib';
 import { Accessory, L_Station, L_Device, LoginResult, LoginFailReason } from './configui/app/util/types';
 import { version } from '../package.json';
-import { version as nodeJSversion, argv as nodeJSargs, env as nodeJSenv } from 'node:process';
-import { satisfies } from 'semver';
 import path from 'path';
 
 class UiServer extends HomebridgePluginUiServer {
@@ -93,7 +91,6 @@ class UiServer extends HomebridgePluginUiServer {
     this.onRequest('/storedAccessories', this.loadStoredAccessories.bind(this));
     this.onRequest('/reset', this.resetPlugin.bind(this));
     this.onRequest('/downloadLogs', this.downloadLogs.bind(this));
-    this.onRequest('/nodeJSVersion', this.nodeJSVersion.bind(this));
   }
 
   /**
@@ -129,20 +126,6 @@ class UiServer extends HomebridgePluginUiServer {
    */
   async resetAccessoryData(): Promise<void> {
     return this.deleteFileIfExists(this.storedAccessories_file);
-  }
-
-  /**
-   * Checks compatibility of the current Node.js version with Livestream functionality.
-   */
-  public nodeJSVersion() {
-    // Define versions known to break compatibility with RSA_PKCS1_PADDING
-    const nodeJSIncompatible = satisfies(nodeJSversion, '>=18.19.1 <19.x || >=20.11.1 <21.x || >=21.6.2 <22');
-    return {
-      nodeJSversion: nodeJSversion,
-      nodeJSIncompatible: nodeJSIncompatible,
-      nodeJSargs: nodeJSargs,
-      nodeJSenv: nodeJSenv,
-    };
   }
 
   async login(options): Promise<LoginResult> {


### PR DESCRIPTION
This pull request adds support for Node.js 22 by removing all compatibility checks that were previously in place due to issues with the RSA_PKCS1_PADDING encryption mechanism.

Changes:
- Removed nodeJSVersion() function and route from server.ts
- Removed all Node.js version compatibility checks from the platform code
- Removed Node.js version warning from the login UI
- Removed semver dependency as it's no longer needed for version checking
- Updated frontend components to not check for Node.js compatibility

These changes allow the plugin to run natively on Node.js 22 without warnings or restrictions.

The eufy-security-client library is now compatible with Node.js 22, which allows us to remove these limitations.