### PR TITLE
Fix #683: Replace @homebridge/camera-utils with pick-port for port allocation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,11 +15,11 @@
       ],
       "license": "Apache-2.0",
       "dependencies": {
-        "@homebridge/camera-utils": "^3.0.0",
         "@homebridge/plugin-ui-utils": "^2.0.2",
         "eufy-security-client": "^3.2.0",
         "ffmpeg-for-homebridge": "2.1.7",
         "fs-extra": "^11.3.0",
+        "pick-port": "^2.1.0",
         "rotating-file-stream": "^3.2.6",
         "tslog": "^4.9.3",
         "zip-lib": "^1.1.2"
@@ -3185,19 +3185,6 @@
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
     },
-    "node_modules/@homebridge/camera-utils": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/@homebridge/camera-utils/-/camera-utils-3.0.0.tgz",
-      "integrity": "sha512-lw+DflCBEgbcfeBfXrPGhbzYn63bj61hpETVwqTO3FCThIMa3VoFDUNEy7jQq6OBS+iaMeHSuv4gy6w8yxFK7A==",
-      "license": "MIT",
-      "dependencies": {
-        "execa": "^9.5.1",
-        "ffmpeg-for-homebridge": "^2.1.7",
-        "pick-port": "^2.1.0",
-        "rxjs": "^7.8.1",
-        "systeminformation": "^5.23.5"
-      }
-    },
     "node_modules/@homebridge/ciao": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@homebridge/ciao/-/ciao-1.3.1.tgz",
@@ -5540,18 +5527,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
-    "node_modules/@sindresorhus/merge-streams": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
-      "integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -7911,6 +7886,7 @@
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
       "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
@@ -9062,32 +9038,6 @@
         "node": ">=0.8.x"
       }
     },
-    "node_modules/execa": {
-      "version": "9.5.2",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-9.5.2.tgz",
-      "integrity": "sha512-EHlpxMCpHWSAh1dgS6bVeoLAXGnJNdR93aabr4QCGbzOM73o5XmRfM/e5FUqsw3aagP8S8XEWUWFAxnRBnAF0Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@sindresorhus/merge-streams": "^4.0.0",
-        "cross-spawn": "^7.0.3",
-        "figures": "^6.1.0",
-        "get-stream": "^9.0.0",
-        "human-signals": "^8.0.0",
-        "is-plain-obj": "^4.1.0",
-        "is-stream": "^4.0.1",
-        "npm-run-path": "^6.0.0",
-        "pretty-ms": "^9.0.0",
-        "signal-exit": "^4.1.0",
-        "strip-final-newline": "^4.0.0",
-        "yoctocolors": "^2.0.0"
-      },
-      "engines": {
-        "node": "^18.19.0 || >=20.5.0"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
     "node_modules/exponential-backoff": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.2.tgz",
@@ -9394,21 +9344,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/figures": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/figures/-/figures-6.1.0.tgz",
-      "integrity": "sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==",
-      "license": "MIT",
-      "dependencies": {
-        "is-unicode-supported": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/file-entry-cache": {
@@ -10364,15 +10299,6 @@
         "node": ">= 14"
       }
     },
-    "node_modules/human-signals": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-8.0.1.tgz",
-      "integrity": "sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=18.18.0"
-      }
-    },
     "node_modules/hyperdyperid": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/hyperdyperid/-/hyperdyperid-1.2.0.tgz",
@@ -10894,18 +10820,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-plain-obj": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
-      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-plain-object": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
@@ -11011,18 +10925,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-unicode-supported": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-2.1.0.tgz",
-      "integrity": "sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -11100,6 +11002,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/isobject": {
@@ -13304,34 +13207,6 @@
         "node": "^18.17.0 || >=20.5.0"
       }
     },
-    "node_modules/npm-run-path": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-6.0.0.tgz",
-      "integrity": "sha512-9qny7Z9DsQU8Ou39ERsPU4OZQlSTP47ShQzuKZ6PRXpYLtIFgl/DEBYEXKlvcEa+9tHVcK8CF81Y2V72qaZhWA==",
-      "license": "MIT",
-      "dependencies": {
-        "path-key": "^4.0.0",
-        "unicorn-magic": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/npm-run-path/node_modules/path-key": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/path-key/-/path-key-4.0.0.tgz",
-      "integrity": "sha512-haREypq7xkM7ErfgIyA0z+Bj4AGKlMSdlQE2jvJo6huWD1EdkKYV+G/T4nq0YEF2vgTT8kqMFKo1uHn950r4SQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/nth-check": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
@@ -13980,18 +13855,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/parse-ms": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/parse-ms/-/parse-ms-4.0.0.tgz",
-      "integrity": "sha512-TXfryirbmq34y8QBwgqCVLi+8oA3oWx2eAnSn62ITyEhEYaWRlVZ2DvMM9eZbMs/RfxPu/PK/aBLyGj4IrqMHw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/parse-node-version": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-node-version/-/parse-node-version-1.0.1.tgz",
@@ -14077,6 +13940,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -14492,21 +14356,6 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
-      }
-    },
-    "node_modules/pretty-ms": {
-      "version": "9.2.0",
-      "resolved": "https://registry.npmjs.org/pretty-ms/-/pretty-ms-9.2.0.tgz",
-      "integrity": "sha512-4yf0QO/sllf/1zbZWYnvWw3NxCQwLXKzIj0G849LSufP15BXKM0rbD2Z3wVnkMfjdn/CB0Dpp444gYAACdsplg==",
-      "license": "MIT",
-      "dependencies": {
-        "parse-ms": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/proc-log": {
@@ -15284,6 +15133,7 @@
       "version": "7.8.2",
       "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.2.tgz",
       "integrity": "sha512-dhKf903U/PQZY6boNNtAGdWbG85WAbjT/1xYoZIC7FAY0yWapOBQVsVrDl58W86//e1VpMNBtRV4MaXfdMySFA==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"
@@ -15709,6 +15559,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "shebang-regex": "^3.0.0"
@@ -15721,6 +15572,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -15815,6 +15667,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
       "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
       "license": "ISC",
       "engines": {
         "node": ">=14"
@@ -16526,18 +16379,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/strip-final-newline": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-4.0.0.tgz",
-      "integrity": "sha512-aulFJcD6YK8V1G7iRB5tigAP4TsHBZZrOV8pjV++zdUwmeV8uzbY7yn6h9MswN62adStNZFuCIx4haBnRuMDaw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -16608,32 +16449,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/systeminformation": {
-      "version": "5.25.11",
-      "resolved": "https://registry.npmjs.org/systeminformation/-/systeminformation-5.25.11.tgz",
-      "integrity": "sha512-jI01fn/t47rrLTQB0FTlMCC+5dYx8o0RRF+R4BPiUNsvg5OdY0s9DKMFmJGrx5SwMZQ4cag0Gl6v8oycso9b/g==",
-      "license": "MIT",
-      "os": [
-        "darwin",
-        "linux",
-        "win32",
-        "freebsd",
-        "openbsd",
-        "netbsd",
-        "sunos",
-        "android"
-      ],
-      "bin": {
-        "systeminformation": "lib/cli.js"
-      },
-      "engines": {
-        "node": ">=8.0.0"
-      },
-      "funding": {
-        "type": "Buy me a coffee",
-        "url": "https://www.buymeacoffee.com/systeminfo"
       }
     },
     "node_modules/tapable": {
@@ -17111,6 +16926,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.3.0.tgz",
       "integrity": "sha512-+QBBXBCvifc56fsbuxZQ6Sic3wqqc3WWaqxs58gvJrcOuN83HGTCwz3oS5phzU9LthRNE9VrJCFCLUgHeeFnfA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -18099,6 +17915,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
       "license": "ISC",
       "dependencies": {
         "isexe": "^2.0.0"
@@ -18557,18 +18374,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/yoctocolors": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/yoctocolors/-/yoctocolors-2.1.1.tgz",
-      "integrity": "sha512-GQHQqAopRhwU8Kt1DDM8NjibDXHC8eoh1erhGAJPEyveY9qqVeXvVikNKrDz69sHowPMorbPUrH/mx8c50eiBQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     "camera"
   ],
   "dependencies": {
-    "@homebridge/camera-utils": "^3.0.0",
     "@homebridge/plugin-ui-utils": "^2.0.2",
     "eufy-security-client": "^3.2.0",
     "ffmpeg-for-homebridge": "2.1.7",
     "fs-extra": "^11.3.0",
+    "pick-port": "^2.1.0",
     "rotating-file-stream": "^3.2.6",
     "tslog": "^4.9.3",
     "zip-lib": "^1.1.2"

--- a/src/plugin/controller/SnapshotManager.ts
+++ b/src/plugin/controller/SnapshotManager.ts
@@ -287,7 +287,7 @@ export class SnapshotManager extends EventEmitter {
   /**
    * Retrieves the newest cloud snapshot's image data.
    * @returns Buffer The image data as a Buffer.
-   * @throws Error if there's no currentSnapshot available.
+   * @throws Error if there's no currentSnapshot available and no fallback image.
    */
   private getSnapshotFromCache(): Buffer {
     // Check if there's a currentSnapshot available
@@ -295,8 +295,14 @@ export class SnapshotManager extends EventEmitter {
       // If available, return the image data
       return this.currentSnapshot.image;
     } else {
-      // If not available, throw an error
-      throw new Error('No currentSnapshot available');
+      // If not available, try to use the unavailable snapshot image
+      if (this.unavailableSnapshot) {
+        this.log.warn('No currentSnapshot available, using fallback unavailable snapshot image');
+        return this.unavailableSnapshot;
+      } else {
+        // If fallback image is also not available, throw an error
+        throw new Error('No currentSnapshot available');
+      }
     }
   }
 

--- a/src/plugin/controller/streamingDelegate.ts
+++ b/src/plugin/controller/streamingDelegate.ts
@@ -24,7 +24,7 @@ import { LocalLivestreamManager } from './LocalLivestreamManager';
 import { SnapshotManager } from './SnapshotManager';
 import { TalkbackStream } from '../utils/Talkback';
 import { HAP, is_rtsp_ready } from '../utils/utils';
-import { reservePorts } from '@homebridge/camera-utils';
+import { pickPort } from 'pick-port';
 import { CameraAccessory } from '../accessories/CameraAccessory';
 import { Logger, ILogObj } from 'tslog';
 
@@ -120,7 +120,10 @@ export class StreamingDelegate implements CameraStreamingDelegate {
 
     this.log.debug(`stream prepare request with session id ${request.sessionID} was received.`);
 
-    const [videoReturnPort, audioReturnPort] = await reservePorts({ type: 'udp', count: 2 });
+    const [videoReturnPort, audioReturnPort] = await Promise.all([
+      pickPort({ type: 'udp' }),
+      pickPort({ type: 'udp' })
+    ]);
 
     const videoSSRC = HAP.CameraController.generateSynchronisationSource();
     const audioSSRC = HAP.CameraController.generateSynchronisationSource();

--- a/src/plugin/platform.ts
+++ b/src/plugin/platform.ts
@@ -579,11 +579,18 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
         return;
       }
 
+      // Check if the device is a keypad and ignore it from the start
+      const deviceType = device.getDeviceType();
+      if (Device.isKeyPad(deviceType)) {
+        log.warn(`${device.getName()}: The keypad is ignored as it serves no purpose in this plugin. You can ignore this message.`);
+        return;
+      }
+
       const deviceContainer: DeviceContainer = {
         deviceIdentifier: {
           uniqueId: device.getSerial(),
           displayName: 'DEVICE ' + device.getName().replace(/[^a-zA-Z0-9]/g, ''),
-          type: device.getDeviceType(),
+          type: deviceType,
         } as DeviceIdentifier,
         eufyDevice: device,
       };
@@ -716,11 +723,6 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
     if (Device.isCamera(type)) {
       log.debug(accessory.displayName + ' isCamera!');
       new CameraAccessory(this, accessory, device as Camera);
-    }
-
-    if (Device.isKeyPad(type)) {
-      log.debug(accessory.displayName + ' isKeypad!');
-      throw new Error('The keypad needs to be taken out because it serves no purpose. You can ignore this message.');
     }
 
   }

--- a/src/plugin/utils/ffmpeg.ts
+++ b/src/plugin/utils/ffmpeg.ts
@@ -4,6 +4,7 @@ import os from 'os';
 import { Readable, Writable } from 'stream';
 
 import ffmpegPath from 'ffmpeg-for-homebridge';
+import { pickPort } from 'pick-port';
 
 import EventEmitter from 'events';
 import { CameraConfig, VideoConfig } from './configTypes';
@@ -20,7 +21,6 @@ import {
 } from 'homebridge';
 import { SessionInfo } from '../controller/streamingDelegate';
 import { ffmpegLogger } from './utils';
-import { reservePorts } from '@homebridge/camera-utils';
 
 class FFmpegProgress extends EventEmitter {
     private server: net.Server;
@@ -143,7 +143,7 @@ export class FFmpegParameters {
     }
 
     static async forAudio(debug = false): Promise<FFmpegParameters> {
-        const [port] = await reservePorts({ type: 'tcp', count: 1 });
+        const port = await pickPort({ type: 'tcp' });
         const ffmpeg = new FFmpegParameters(port, false, true, false, debug);
         ffmpeg.useWallclockAsTimestamp = false;
         ffmpeg.flagsGlobalHeader = true;
@@ -151,12 +151,12 @@ export class FFmpegParameters {
     }
 
     static async forVideo(debug = false): Promise<FFmpegParameters> {
-        const [port] = await reservePorts({ type: 'tcp', count: 1 });
+        const port = await pickPort({ type: 'tcp' });
         return new FFmpegParameters(port, true, false, false, debug);
     }
 
     static async forSnapshot(debug = false): Promise<FFmpegParameters> {
-        const [port] = await reservePorts({ type: 'tcp', count: 1 });
+        const port = await pickPort({ type: 'tcp' });
         const ffmpeg = new FFmpegParameters(port, false, false, true, debug);
         ffmpeg.useWallclockAsTimestamp = false;
         ffmpeg.numberFrames = 1;
@@ -165,14 +165,14 @@ export class FFmpegParameters {
     }
 
     static async forVideoRecording(debug = false): Promise<FFmpegParameters> {
-        const [port] = await reservePorts({ type: 'tcp', count: 1 });
+        const port = await pickPort({ type: 'tcp' });
         const ffmpeg = new FFmpegParameters(port, true, false, false, debug);
         ffmpeg.useWallclockAsTimestamp = true;
         return ffmpeg;
     }
 
     static async forAudioRecording(debug = false): Promise<FFmpegParameters> {
-        const [port] = await reservePorts({ type: 'tcp', count: 1 });
+        const port = await pickPort({ type: 'tcp' });
         const ffmpeg = new FFmpegParameters(port, false, true, false, debug);
         return ffmpeg;
     }
@@ -191,7 +191,7 @@ export class FFmpegParameters {
     }
 
     public async setInputStream(input: Readable) {
-        const [port] = await reservePorts({ type: 'tcp', count: 1 });
+        const port = await pickPort({ type: 'tcp' });
         let killTimeout: NodeJS.Timeout | undefined = undefined;
         const server = net.createServer((socket) => {
             if (killTimeout) {
@@ -480,7 +480,7 @@ export class FFmpegParameters {
             'config=F8F0212C00BC00\r\n' +
             'a=crypto:1 AES_CM_128_HMAC_SHA1_80 inline:' + sessionInfo.audioSRTP.toString('base64') + '\r\n';
 
-        const [port] = await reservePorts({ type: 'tcp', count: 1 });
+        const port = await pickPort({ type: 'tcp' });
         let killTimeout: NodeJS.Timeout | undefined = undefined;
         const server = net.createServer((socket) => {
             if (killTimeout) {
@@ -869,7 +869,7 @@ export class FFmpeg extends EventEmitter {
         this.progress = new FFmpegProgress(this.parameters[0].progressPort);
         this.progress.on('progress started', this.onProgressStarted.bind(this));
 
-        const [port] = await reservePorts({ type: 'tcp', count: 1 });
+        const port = await pickPort({ type: 'tcp' });
 
         return new Promise((resolve) => {
             const server = net.createServer((socket) => {


### PR DESCRIPTION
This pull request addresses issue #683 by replacing the `reservePorts` function from `@homebridge/camera-utils` with the `pickPort` function from the `pick-port` package.

### Fix
 - Use fallback image when no snapshot is available in cache
 - Replaces the error thrown when detecting keypads with a warning log message

### Changes
 - Removed dependency on `@homebridge/camera-utils` for port allocation
 - Added dependency on `pick-port` package
 - Modified port reservation logic in `ffmpeg.ts` and `streamingDelegate.ts`
 - Updated all instances where ports are reserved to use the new API

### Implementation Details
 - Changed `const [port] = await reservePorts({ type: 'tcp', count: 1 })` to `const port = await pickPort({ type: 'tcp' })`
 - For multiple ports, replaced single calls to `reservePorts` with multiple parallel calls to pickPort using Promise.all
 - Updated import statements accordingly