### PR TITLE
Enhance livestream error handling and add embedded PKCS1 support

### DIFF
--- a/src/configui/app/advanced-config-options/advanced-config-options.component.html
+++ b/src/configui/app/advanced-config-options/advanced-config-options.component.html
@@ -19,4 +19,6 @@
 <hr />
 <app-clean-cache></app-clean-cache>
 <hr />
+<app-embedded-pkcs1-support></app-embedded-pkcs1-support>
+<hr />
 <app-guard-modes-mapping></app-guard-modes-mapping>

--- a/src/configui/app/advanced-config-options/advanced-config-options.component.ts
+++ b/src/configui/app/advanced-config-options/advanced-config-options.component.ts
@@ -9,6 +9,7 @@ import { PollingIntervalMinutesComponent } from '../config-options/polling-inter
 import { EditCredentialsComponent } from '../config-options/edit-credentials/edit-credentials.component';
 import { AutoSyncStationComponent } from '../config-options/auto-sync-station/auto-sync-station.component';
 import { LucideAngularModule } from 'lucide-angular';
+import { EmbeddedPKCS1SupportComponent } from '../config-options/embedded-pkcs1-support/embedded-pkcs1-support.component';
 
 @Component({
     selector: 'app-advanced-config-options',
@@ -22,6 +23,7 @@ import { LucideAngularModule } from 'lucide-angular';
         IgnoreMultipleDevicesWarningComponent,
         OmitLogFilesComponent,
         CleanCacheComponent,
+        EmbeddedPKCS1SupportComponent,
         GuardModesMappingComponent,
         AutoSyncStationComponent,
         LucideAngularModule,

--- a/src/configui/app/config-options/embedded-pkcs1-support/embedded-pkcs1-support.component.html
+++ b/src/configui/app/config-options/embedded-pkcs1-support/embedded-pkcs1-support.component.html
@@ -1,0 +1,14 @@
+<div class="settingsItem">
+  <div class="d-flex justify-content-between align-items-center mb-2">
+    <label for="enableEmbeddedPKCS1Support">Enable Embedded PKCS1 Support</label>
+
+    <div class="form-check form-switch">
+      <input class="form-check-input" type="checkbox" role="switch" [(ngModel)]="enableEmbeddedPKCS1Support" id="enableEmbeddedPKCS1Support"
+        (change)="update()">
+    </div>
+  </div>
+
+  <small><i>
+      Starting from Node.js versions 18.19.1, 20.11.1, and 21.6.2, the removal of RSA_PKCS1_PADDING support breaks Eufy Security's livestream/P2P functionality. We've developed a countermeasure based on software calculation, it will be 10x times less effective than hardware but it can make some cameras work on Node.js 22+. <a href="https://github.com/homebridge-eufy-security/plugin/wiki/Node.js-Compatibility-with-Eufy-Security-Plugin" target="_blank">More technical details here</a>.
+    </i></small>
+</div>

--- a/src/configui/app/config-options/embedded-pkcs1-support/embedded-pkcs1-support.component.ts
+++ b/src/configui/app/config-options/embedded-pkcs1-support/embedded-pkcs1-support.component.ts
@@ -1,0 +1,41 @@
+import { Component, OnInit } from '@angular/core';
+import { PluginService } from '../../plugin.service';
+import { ConfigOptionsInterpreter } from '../config-options-interpreter';
+import { FormsModule } from '@angular/forms';
+import { DEFAULT_CONFIG_VALUES } from '../../util/default-config-values';
+
+@Component({
+  selector: 'app-embedded-pkcs1-support',
+  templateUrl: './embedded-pkcs1-support.component.html',
+  standalone: true,
+  imports: [FormsModule],
+})
+export class EmbeddedPKCS1SupportComponent extends ConfigOptionsInterpreter implements OnInit {
+
+  enableEmbeddedPKCS1Support = DEFAULT_CONFIG_VALUES.enableEmbeddedPKCS1Support;
+
+  constructor(pluginService: PluginService) {
+    super(pluginService);
+  }
+  
+  async ngOnInit(): Promise<void> {
+    this.readValue();
+  }
+
+  /** Customize from here */
+  /** updateConfig() will overwrite any settings that you'll provide */
+  /** Don't try and 'append'/'push' to arrays this way - add a custom method instead */
+  /** see config option to ignore devices as example */
+
+  /** updateConfig() takes an optional second parameter to specify the accessoriy for which the setting is changed */
+
+  readValue() {
+    this.enableEmbeddedPKCS1Support = this.config['cleanCache'] ?? this.enableEmbeddedPKCS1Support;
+  }
+
+  update() {
+    this.updateConfig({
+      enableEmbeddedPKCS1Support: this.enableEmbeddedPKCS1Support,
+    });
+  }
+}

--- a/src/configui/app/config-options/embedded-pkcs1-support/embedded-pkcs1-support.component.ts
+++ b/src/configui/app/config-options/embedded-pkcs1-support/embedded-pkcs1-support.component.ts
@@ -30,7 +30,7 @@ export class EmbeddedPKCS1SupportComponent extends ConfigOptionsInterpreter impl
   /** updateConfig() takes an optional second parameter to specify the accessoriy for which the setting is changed */
 
   readValue() {
-    this.enableEmbeddedPKCS1Support = this.config['cleanCache'] ?? this.enableEmbeddedPKCS1Support;
+    this.enableEmbeddedPKCS1Support = this.config['enableEmbeddedPKCS1Support'] ?? this.enableEmbeddedPKCS1Support;
   }
 
   update() {

--- a/src/configui/app/util/default-config-values.ts
+++ b/src/configui/app/util/default-config-values.ts
@@ -23,6 +23,7 @@ export const DEFAULT_CONFIG_VALUES: EufySecurityPlatformConfig = {
   cleanCache: true,
   ignoreMultipleDevicesWarning: false,
   autoSyncStation: false,
+  enableEmbeddedPKCS1Support: false,
 };
 
 export const DEFAULT_CAMERACONFIG_VALUES: CameraConfig = {

--- a/src/plugin/config.ts
+++ b/src/plugin/config.ts
@@ -27,6 +27,7 @@ export interface EufySecurityPlatformConfig extends PlatformConfig {
   cleanCache: boolean;
   ignoreMultipleDevicesWarning: boolean;
   autoSyncStation: boolean;
+  enableEmbeddedPKCS1Support: boolean;
 }
 
 export const DEFAULT_CONFIG_VALUES: EufySecurityPlatformConfig = {
@@ -51,4 +52,5 @@ export const DEFAULT_CONFIG_VALUES: EufySecurityPlatformConfig = {
   cleanCache: true,
   ignoreMultipleDevicesWarning: false,
   autoSyncStation: false,
+  enableEmbeddedPKCS1Support: false,
 };

--- a/src/plugin/controller/LocalLivestreamManager.ts
+++ b/src/plugin/controller/LocalLivestreamManager.ts
@@ -80,13 +80,14 @@ export class LocalLivestreamManager extends EventEmitter {
       const hardStop = setTimeout(
         () => {
           this.log.error('Livestream timeout: No livestream emitted within the expected timeframe.');
-          this.log.warn('If you are using Node.js version 18.19.1, 20.11.1, 21.6.2 or newer, this might be related to RSA_PKCS1_PADDING support removal.');
+          const problematicNodeVersions = ['18.19.1', '20.11.1', '21.6.2'];
+          this.log.warn(`If you are using Node.js version ${problematicNodeVersions.join(', ')} or newer, this might be related to RSA_PKCS1_PADDING support removal.`);
           this.log.warn('Please try enabling "Embedded PKCS1 Support" in the plugin settings to resolve this issue.');
           this.stopLocalLiveStream();
           this.livestreamIsStarting = false;
           reject('No livestream emitted... This may be due to Node.js compatibility issues. Try enabling Embedded PKCS1 Support in settings.');
         },
-        15 * 1000 // After 15sec Apple HK will disconnect so all of this for nothing...
+        15 * 1000 // After 15 seconds, Apple HomeKit may disconnect, invalidating the livestream setup.
       );
 
       this.once('livestream start', async () => {

--- a/src/plugin/controller/LocalLivestreamManager.ts
+++ b/src/plugin/controller/LocalLivestreamManager.ts
@@ -80,11 +80,13 @@ export class LocalLivestreamManager extends EventEmitter {
       const hardStop = setTimeout(
         () => {
           this.log.error('Livestream timeout: No livestream emitted within the expected timeframe.');
+          this.log.warn('If you are using Node.js version 18.19.1, 20.11.1, 21.6.2 or newer, this might be related to RSA_PKCS1_PADDING support removal.');
+          this.log.warn('Please try enabling "Embedded PKCS1 Support" in the plugin settings to resolve this issue.');
           this.stopLocalLiveStream();
           this.livestreamIsStarting = false;
-          reject('No livestream emited... Something wrong between HB and your cam!');
+          reject('No livestream emitted... This may be due to Node.js compatibility issues. Try enabling Embedded PKCS1 Support in settings.');
         },
-        15 * 1000 // After 10sec Apple HK will disconnect so all of this for nothing...
+        15 * 1000 // After 15sec Apple HK will disconnect so all of this for nothing...
       );
 
       this.once('livestream start', async () => {

--- a/src/plugin/platform.ts
+++ b/src/plugin/platform.ts
@@ -319,6 +319,7 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
       persistentDir: this.eufyPath,
       p2pConnectionSetup: 0,
       pollingIntervalMinutes: this.config.pollingIntervalMinutes,
+      enableEmbeddedPKCS1Support:  this.config.enableEmbeddedPKCS1Support,
       eventDurationSeconds: 10,
       logging: {
         level: (this.config.enableDetailedLogging) ? LogLevel.Debug : LogLevel.Info,


### PR DESCRIPTION
Improve error handling for livestream failures by providing specific guidance on Node.js compatibility issues. Introduce an option for enabling "Embedded PKCS1 Support" to help users work around the removal of RSA_PKCS1_PADDING support in newer Node.js versions. Update configuration and UI components accordingly.