### PR TITLE
Revert Node engine version to 20.11.0 in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "url": "https://github.com/homebridge-eufy-security/plugin/issues"
   },
   "engines": {
-    "node": "^20.15.1 || ^22",
+    "node": "20.11.0 || ^22",
     "homebridge": "^1.8.0 || ^2.0.0-beta.0"
   },
   "main": "dist/index.js",


### PR DESCRIPTION
Revert the Node engine version in package.json to ensure compatibility with specific environments.