### PR TITLE
Update version file paths and TypeScript configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,7 @@ dist
 
 homebridge-ui/
 
-src/plugin/version.ts
+configui/plugin/version.ts
+src/version.ts
 
 TODO

--- a/.gitignore
+++ b/.gitignore
@@ -128,7 +128,7 @@ dist
 
 homebridge-ui/
 
-configui/plugin/version.ts
+src/plugin/version.ts
 src/version.ts
 
 TODO

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "4.3.6",
   "description": "Control Eufy Security from homebridge.",
   "license": "Apache-2.0",
+  "type": "module",
   "repository": {
     "type": "git",
     "url": "git://github.com/homebridge-eufy-security/plugin.git"
@@ -30,7 +31,7 @@
     "build-plugin": "rimraf ./dist && tsc --project tsconfig.plugin.json",
     "build-configui": "rimraf ./homebridge-ui && ng build --base-href /api/plugins/settings-ui/homebridge-eufy-security/ && tsc --project tsconfig.configui.server.json",
     "postbuild": "cp -r ./media ./dist/media",
-    "prebuild": "node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/plugin/version.ts",
+    "prebuild": "node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/plugin/version.ts && node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
     "serve-configui": "ng serve",
     "prepublishOnly": "npm run lint && npm run build"
   },

--- a/src/server.ts
+++ b/src/server.ts
@@ -4,8 +4,8 @@ import * as fs from 'fs';
 import { Logger as TsLogger, ILogObj } from 'tslog';
 import { createStream } from 'rotating-file-stream';
 import { Zip } from 'zip-lib';
-import { Accessory, L_Station, L_Device, LoginResult, LoginFailReason } from './configui/app/util/types';
-import { version } from '../package.json';
+import { Accessory, L_Station, L_Device, LoginResult, LoginFailReason } from './configui/app/util/types.js';
+import { LIB_VERSION } from './version.js';
 import path from 'path';
 
 class UiServer extends HomebridgePluginUiServer {
@@ -43,7 +43,7 @@ class UiServer extends HomebridgePluginUiServer {
 
   private initLogger() {
     this.log = new TsLogger({
-      name: `[${version}]`,
+      name: `[${LIB_VERSION}]`,
       prettyLogTemplate: '{{name}}\t{{logLevelName}}\t[{{fileNameWithLine}}]\t',
       prettyErrorTemplate: '\n{{errorName}} {{errorMessage}}\nerror stack:\n{{errorStack}}',
       prettyErrorStackTemplate: '  • {{fileName}}\t{{method}}\n\t{{fileNameWithLine}}',
@@ -222,10 +222,10 @@ class UiServer extends HomebridgePluginUiServer {
       const { version: storedVersion, stations: storedAccessories } = JSON.parse(storedData);
 
       // Compare the stored version with the current version
-      if (storedVersion !== version) {
+      if (storedVersion !== LIB_VERSION) {
         // If the versions do not match, log a warning and push an event
-        this.pushEvent('versionUnmatched', { currentVersion: version, storedVersion: storedVersion });
-        this.log.warn(`Stored version (${storedVersion}) does not match current version (${version})`);
+        this.pushEvent('versionUnmatched', { currentVersion: LIB_VERSION, storedVersion: storedVersion });
+        this.log.warn(`Stored version (${storedVersion}) does not match current version (${LIB_VERSION})`);
       }
 
       // Return the parsed accessories
@@ -341,7 +341,7 @@ class UiServer extends HomebridgePluginUiServer {
   }
 
   storeAccessories() {
-    const dataToStore = { version: version, stations: this.stations };
+    const dataToStore = { version: LIB_VERSION, stations: this.stations };
     fs.writeFileSync(this.storedAccessories_file, JSON.stringify(dataToStore));
   }
 

--- a/tsconfig.configui.server.json
+++ b/tsconfig.configui.server.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "lib": [
       "es2022",
       "dom"
@@ -18,7 +18,8 @@
     "resolveJsonModule": true,
   },
   "include": [
-    "src/server.ts"
+    "src/server.ts",
+    "src/version.ts"
   ],
   "exclude": [
     "**/*.spec.ts"


### PR DESCRIPTION
Adjust paths for version files in `.gitignore` and modify TypeScript configuration for module compatibility. This ensures proper handling of module imports and exports.