### PR TITLE
fix: HKSV recording delegate implementation

### DIFF
--- a/src/plugin/accessories/BaseAccessory.ts
+++ b/src/plugin/accessories/BaseAccessory.ts
@@ -252,8 +252,16 @@ export abstract class BaseAccessory extends EventEmitter {
   }
 
   protected pruneUnusedServices() {
+    // Services managed by CameraController must never be pruned.
+    // CameraController creates these automatically during configureController()
+    // and they are not tracked in servicesInUse.
     const safeServiceUUIDs = [
-      SERV.CameraRTPStreamManagement.UUID,
+      SERV.CameraRTPStreamManagement.UUID,      // 00000110
+      '0000021A-0000-1000-8000-0026BB765291',    // CameraOperatingMode (HKSV)
+      '00000204-0000-1000-8000-0026BB765291',    // CameraRecordingManagement (HKSV)
+      '00000129-0000-1000-8000-0026BB765291',    // DataStreamTransportManagement (HKSV)
+      SERV.Microphone.UUID,                      // 00000112 (created by CameraController)
+      SERV.Speaker.UUID,                         // 00000113 (created by CameraController)
     ];
 
     this.accessory.services.forEach((service) => {

--- a/src/plugin/accessories/CameraAccessory.ts
+++ b/src/plugin/accessories/CameraAccessory.ts
@@ -576,6 +576,24 @@ export class CameraAccessory extends DeviceAccessory {
       }
 
       this.log.debug(`configureController`);
+
+      // Remove stale controller-managed services from cache before configuring.
+      // When HSV is enabled, CameraController creates CameraOperatingMode and
+      // DataStreamTransportManagement services automatically. If the cached
+      // accessory already has them (e.g. from a previous run), configureController
+      // will throw a duplicate UUID error.
+      const controllerManagedServiceUUIDs = [
+        '0000021A-0000-1000-8000-0026BB765291', // CameraOperatingMode
+        '00000129-0000-1000-8000-0026BB765291', // DataStreamTransportManagement
+      ];
+      for (const uuid of controllerManagedServiceUUIDs) {
+        const existingService = this.accessory.services.find(s => s.UUID === uuid);
+        if (existingService) {
+          this.log.debug(`Removing stale cached service ${uuid} before configureController`);
+          this.accessory.removeService(existingService);
+        }
+      }
+
       this.accessory.configureController(controller);
 
     } catch (error) {

--- a/src/plugin/utils/ffmpeg.ts
+++ b/src/plugin/utils/ffmpeg.ts
@@ -361,7 +361,7 @@ export class FFmpegParameters {
     }
 
     public setupForRecording(videoConfig: VideoConfig, configuration: CameraRecordingConfiguration) {
-        this.movflags = 'frag_keyframe+empty_moov+default_base_moof';
+        this.movflags = 'frag_keyframe+empty_moov+default_base_moof+omit_tfhd_offset';
         this.maxMuxingQueueSize = 1024;
 
         if (videoConfig.videoProcessor && videoConfig.videoProcessor !== '') {
@@ -389,7 +389,7 @@ export class FFmpegParameters {
                         : configuration.videoCodec.parameters.level === H264Level.LEVEL3_2
                             ? '3.2'
                             : '3.1';
-                this.codecOptions = `-profile:v ${profile} -level:v ${level}`;
+                this.codecOptions = `-preset ultrafast -tune zerolatency -profile:v ${profile} -level:v ${level}`;
             }
             if (this.codec !== 'copy') {
                 this.bitrate = videoConfig.maxBitrate ?? configuration.videoCodec.parameters.bitRate;


### PR DESCRIPTION
## Summary

Fixes HomeKit Secure Video (HKSV) recording not working — only regular streaming was functional.

## Root Causes & Fixes

### 1. HKSV services pruned on startup (main issue)
`pruneUnusedServices()` was removing `CameraRecordingManagement`, `CameraOperatingMode`, `DataStreamTransportManagement`, `Microphone`, and `Speaker` services created by `CameraController`. Without these, HomeKit never negotiated HKSV.

**Fix:** Added all CameraController-managed service UUIDs to the safe list in `BaseAccessory.ts`.

### 2. Duplicate UUID crash on restart
Cached accessories retained stale controller-managed services, causing `configureController()` to throw duplicate UUID errors.

**Fix:** Remove stale cached services before `configureController()` in `CameraAccessory.ts`.

### 3. Wrong fMP4 fragment structure
Fragments were not properly structured for HKSV (init segment: ftyp+moov, then moof+mdat pairs).

**Fix:** Rewrote fragment yielding logic in `recordingDelegate.ts` to match HKSV spec.

### 4. Incorrect isLast flag
`isLast: !motionDetected` was set on every fragment, causing HKSV to drop recordings.

**Fix:** Always yield `isLast: false` during streaming; check motion after yield.

### 5. Missing omit_tfhd_offset movflag
Required for HKSV fMP4 compatibility.

### 6. Missing encoding preset for recording
Added `-preset ultrafast -tune zerolatency` to prevent FFmpeg buffering delays.

## Files Changed
- `src/plugin/accessories/BaseAccessory.ts`
- `src/plugin/accessories/CameraAccessory.ts`
- `src/plugin/controller/recordingDelegate.ts`
- `src/plugin/utils/ffmpeg.ts`

## Summary by Sourcery

Fix HomeKit Secure Video recording by preserving and correctly managing camera controller services, restructuring HKSV recording fragments, and tuning FFmpeg settings for HKSV compatibility and low-latency recording.

Bug Fixes:
- Prevent pruning of CameraController-managed services required for HKSV negotiation so HKSV recording functions correctly.
- Remove stale cached controller-managed services before configuring the camera controller to avoid duplicate UUID errors on restart.
- Correct the fMP4 fragmenting logic to emit a valid HKSV initialization segment and moof/mdat fragment pairs, and to avoid prematurely marking fragments as last based on motion state.

Enhancements:
- Improve HKSV recording logging with per-fragment metrics and overall fragment/byte counts for completed recordings.
- Adjust FFmpeg movflags and codec options, including omit_tfhd_offset and low-latency presets, to ensure HKSV compatibility and reduce buffering delays.