### PR TITLE
refactor: remove HKSV enable/disable toggle, make HKSV default

### DIFF
--- a/homebridge-ui/public/views/device-detail.js
+++ b/homebridge-ui/public/views/device-detail.js
@@ -205,16 +205,6 @@ const DeviceDetailView = {
       hsvTitle.textContent = 'HomeKit Secure Video';
       advSection.appendChild(hsvTitle);
 
-      Toggle.render(advSection, {
-        id: 'toggle-hsv',
-        label: 'Enable HSV',
-        help: 'Enable HomeKit Secure Video recording. Requires an iCloud+ plan with HomeKit Secure Video support.',
-        checked: !!deviceConfig.hsv,
-        onChange: async (checked) => {
-          await Config.updateDeviceConfig(device.uniqueId, { hsv: checked });
-        },
-      });
-
       NumberInput.render(advSection, {
         id: 'num-hsv-duration',
         label: 'HSV Recording Duration',

--- a/src/plugin/accessories/BaseAccessory.ts
+++ b/src/plugin/accessories/BaseAccessory.ts
@@ -275,23 +275,4 @@ export abstract class BaseAccessory extends EventEmitter {
     });
   }
 
-  protected handleDummyEventGet(serviceName: string): Promise<CharacteristicValue> {
-    const characteristicValues: Record<string, CharacteristicValue> = {
-      'EventSnapshotsActive': CHAR.EventSnapshotsActive.DISABLE,
-      'HomeKitCameraActive': CHAR.HomeKitCameraActive.OFF,
-    };
-
-    const currentValue = characteristicValues[serviceName];
-
-    if (currentValue === undefined) {
-      throw new Error(`Invalid serviceName: ${serviceName}`);
-    }
-
-    this.log.debug(`IGNORE GET ${serviceName}: ${currentValue}`);
-    return Promise.resolve(currentValue);
-  }
-
-  protected handleDummyEventSet(serviceName: string, value: CharacteristicValue) {
-    this.log.debug(`IGNORE SET ${serviceName}: ${value}`);
-  }
 }

--- a/src/plugin/accessories/CameraAccessory.ts
+++ b/src/plugin/accessories/CameraAccessory.ts
@@ -261,98 +261,6 @@ export class CameraAccessory extends DeviceAccessory {
 
   private cameraFunction() {
 
-    if (!this.cameraConfig.hsv) {
-      this.registerCharacteristic({
-        serviceType: SERV.CameraOperatingMode,
-        characteristicType: CHAR.EventSnapshotsActive,
-        getValue: () => this.handleDummyEventGet('EventSnapshotsActive'),
-        setValue: (value) => this.handleDummyEventSet('EventSnapshotsActive', value),
-      });
-
-      this.registerCharacteristic({
-        serviceType: SERV.CameraOperatingMode,
-        characteristicType: CHAR.HomeKitCameraActive,
-        getValue: (data, characteristic) =>
-          this.getCameraPropertyValue(characteristic, PropertyName.DeviceEnabled),
-        setValue: (value, characteristic) =>
-          this.setCameraPropertyValue(characteristic, PropertyName.DeviceEnabled, value),
-        onValue: (service, characteristic) => {
-           
-          this.device.on('property changed', (device: any, name: string, value: PropertyValue) => {
-            this.applyPropertyValue(characteristic, PropertyName.DeviceEnabled, value);
-          });
-        },
-      });
-
-      if (this.device.hasProperty('enabled')) {
-        this.registerCharacteristic({
-          serviceType: SERV.CameraOperatingMode,
-          characteristicType: CHAR.ManuallyDisabled,
-          getValue: (data, characteristic) =>
-            this.getCameraPropertyValue(characteristic, PropertyName.DeviceEnabled),
-          onValue: (service, characteristic) => {
-             
-            this.device.on('property changed', (device: any, name: string, value: PropertyValue) => {
-              this.applyPropertyValue(characteristic, PropertyName.DeviceEnabled, value);
-            });
-          },
-        });
-      }
-
-      if (this.device.hasProperty('statusLed')) {
-        this.registerCharacteristic({
-          serviceType: SERV.CameraOperatingMode,
-          characteristicType: CHAR.CameraOperatingModeIndicator,
-          getValue: (data, characteristic) =>
-            this.getCameraPropertyValue(characteristic, PropertyName.DeviceStatusLed),
-          setValue: (value, characteristic) =>
-            this.setCameraPropertyValue(characteristic, PropertyName.DeviceStatusLed, value),
-          onValue: (service, characteristic) => {
-             
-            this.device.on('property changed', (device: any, name: string, value: PropertyValue) => {
-              this.applyPropertyValue(characteristic, PropertyName.DeviceStatusLed, value);
-            });
-          },
-        });
-      }
-
-      if (this.device.hasProperty('nightvision')) {
-        this.registerCharacteristic({
-          serviceType: SERV.CameraOperatingMode,
-          characteristicType: CHAR.NightVision,
-          getValue: (data, characteristic) =>
-            this.getCameraPropertyValue(characteristic, PropertyName.DeviceNightvision),
-          setValue: (value, characteristic) =>
-            this.setCameraPropertyValue(characteristic, PropertyName.DeviceNightvision, value),
-          onValue: (service, characteristic) => {
-             
-            this.device.on('property changed', (device: any, name: string, value: PropertyValue) => {
-              this.applyPropertyValue(characteristic, PropertyName.DeviceNightvision, value);
-            });
-          },
-        });
-      }
-
-      if (this.device.hasProperty('autoNightvision')) {
-        this.registerCharacteristic({
-          serviceType: SERV.CameraOperatingMode,
-          characteristicType: CHAR.NightVision,
-          getValue: (data, characteristic) =>
-            this.getCameraPropertyValue(characteristic, PropertyName.DeviceAutoNightvision),
-          setValue: (value, characteristic) =>
-            this.setCameraPropertyValue(characteristic, PropertyName.DeviceAutoNightvision, value),
-          onValue: (service, characteristic) => {
-             
-            this.device.on('property changed', (device: any, name: string, value: PropertyValue) => {
-              this.applyPropertyValue(characteristic, PropertyName.DeviceAutoNightvision, value);
-            });
-          },
-        });
-      }
-
-      this.getService(SERV.CameraOperatingMode).setPrimaryService(true);
-    }
-
     // Fire snapshot when motion detected
     this.registerCharacteristic({
       serviceType: SERV.MotionSensor,
@@ -570,10 +478,8 @@ export class CameraAccessory extends DeviceAccessory {
       this.log.debug(`streamingDelegate.setController`);
       this.streamingDelegate.setController(controller);
 
-      if (this.cameraConfig.hsv) {
-        this.log.debug(`recordingDelegate.setController`);
-        this.recordingDelegate.setController(controller);
-      }
+      this.log.debug(`recordingDelegate.setController`);
+      this.recordingDelegate.setController(controller);
 
       this.log.debug(`configureController`);
 
@@ -626,46 +532,42 @@ export class CameraAccessory extends DeviceAccessory {
           ],
         },
       },
-      recording: this.cameraConfig.hsv
-        ? {
-          options: {
-            overrideEventTriggerOptions: [
-              EventTriggerOption.MOTION,
-              EventTriggerOption.DOORBELL,
-            ],
-            prebufferLength: 0, // prebufferLength always remains 4s ?
-            mediaContainerConfiguration: [
-              {
-                type: MediaContainerType.FRAGMENTED_MP4,
-                fragmentLength: 4000,
-              },
-            ],
-            video: {
-              type: this.platform.api.hap.VideoCodecType.H264,
-              parameters: {
-                profiles: [H264Profile.BASELINE, H264Profile.MAIN, H264Profile.HIGH],
-                levels: [H264Level.LEVEL3_1, H264Level.LEVEL3_2, H264Level.LEVEL4_0],
-              },
-              resolutions: this.resolutions,
+      recording: {
+        options: {
+          overrideEventTriggerOptions: [
+            EventTriggerOption.MOTION,
+            EventTriggerOption.DOORBELL,
+          ],
+          prebufferLength: 0, // prebufferLength always remains 4s ?
+          mediaContainerConfiguration: [
+            {
+              type: MediaContainerType.FRAGMENTED_MP4,
+              fragmentLength: 4000,
             },
-            audio: {
-              codecs: {
-                type: AudioRecordingCodecType.AAC_ELD,
-                samplerate: AudioRecordingSamplerate.KHZ_24,
-                bitrateMode: 0,
-                audioChannels: 1,
-              },
+          ],
+          video: {
+            type: this.platform.api.hap.VideoCodecType.H264,
+            parameters: {
+              profiles: [H264Profile.BASELINE, H264Profile.MAIN, H264Profile.HIGH],
+              levels: [H264Level.LEVEL3_1, H264Level.LEVEL3_2, H264Level.LEVEL4_0],
+            },
+            resolutions: this.resolutions,
+          },
+          audio: {
+            codecs: {
+              type: AudioRecordingCodecType.AAC_ELD,
+              samplerate: AudioRecordingSamplerate.KHZ_24,
+              bitrateMode: 0,
+              audioChannels: 1,
             },
           },
-          delegate: this.recordingDelegate as RecordingDelegate,
-        }
-        : undefined,
-      sensors: this.cameraConfig.hsv
-        ? {
-          motion: this.getService(SERV.MotionSensor),
-          occupancy: undefined,
-        }
-        : undefined,
+        },
+        delegate: this.recordingDelegate as RecordingDelegate,
+      },
+      sensors: {
+        motion: this.getService(SERV.MotionSensor),
+        occupancy: undefined,
+      },
     };
 
     return option;

--- a/src/plugin/utils/configTypes.ts
+++ b/src/plugin/utils/configTypes.ts
@@ -21,7 +21,6 @@ export type CameraConfig = {
   delayCameraSnapshot?: boolean;
   talkback?: boolean;
   talkbackChannels?: number;
-  hsv?: boolean;
   hsvRecordingDuration?: number;
   indoorChimeButton?: boolean;
 };
@@ -37,7 +36,6 @@ export const DEFAULT_CAMERACONFIG_VALUES: CameraConfig = {
   lightButton: true,
   talkback: false,
   talkbackChannels: 1,
-  hsv: false,
   hsvRecordingDuration: 90,
   rtsp: false,
   enableCamera: true,


### PR DESCRIPTION
## Summary

Remove the option to enable/disable HKSV (HomeKit Secure Video). HKSV is now always active when a camera is enabled, eliminating the need for a manual toggle and simplifying the codebase.

## Changes

### `src/plugin/utils/configTypes.ts`
- Removed `hsv` property from `CameraConfig` type
- Removed `hsv: false` default value (no longer needed since HKSV is always on)

### `src/plugin/accessories/CameraAccessory.ts`
- Removed the entire `if (!this.cameraConfig.hsv)` block that manually registered `CameraOperatingMode` characteristics (`EventSnapshotsActive`, `HomeKitCameraActive`, `ManuallyDisabled`, `CameraOperatingModeIndicator`, `NightVision`) — these are now managed automatically by the `CameraController` when HKSV is active
- Removed conditional guard around `recordingDelegate.setController()` — always wired up now
- `recording` and `sensors` options in `CameraControllerOptions` are now always provided instead of being conditionally set based on `hsv` flag

### `src/plugin/accessories/BaseAccessory.ts`
- Removed unused `handleDummyEventGet()` and `handleDummyEventSet()` methods (were only used by the removed non-HKSV code path)

### `homebridge-ui/public/views/device-detail.js`
- Removed the "Enable HSV" toggle from the device detail UI
- HSV Recording Duration setting is preserved for user configuration

## Impact

- **Breaking**: Users who had `hsv: false` in their config will now get HKSV enabled automatically. The `hsv` property in existing configs will be silently ignored.
- **Net reduction**: 164 lines removed, 35 added across 4 files.

## Summary by Sourcery

Always enable HomeKit Secure Video for camera accessories and remove configuration/UI support for disabling it.

New Features:
- Enable HomeKit Secure Video recording and sensor support by default for all enabled cameras.

Enhancements:
- Simplify camera controller setup by unconditionally wiring the recording delegate and sensor options.
- Remove legacy non-HKSV camera operating mode characteristics and associated dummy handlers.

Chores:
- Remove the deprecated `hsv` option from camera config types and default values, and drop the corresponding UI toggle in the device detail view.