### PR TITLE
Modernize plugin to native ESM module system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -557,7 +557,6 @@
       "integrity": "sha512-4z2nCSBfVIMnbuu8uinj+f0o4qOeggYJLbjpPHka3KH1om7e+H9yLKTYgksTaHcGco+NClhhY2vyO3HsMH1RGw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.55.0",
         "@typescript-eslint/types": "8.55.0",
@@ -774,7 +773,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1386,7 +1384,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3575,7 +3572,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3698,7 +3694,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -3711,8 +3706,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/typescript-logging/-/typescript-logging-2.2.0.tgz",
       "integrity": "sha512-mPKFGAgGJmeCqrzA6B64Lqoz6vLPtxa8yCd7sWAnfrz9opuNlxqW57VxjtEOL0OOoQeTdc/kBjGUh8sieBXa8A==",
-      "license": "Apache-2.0",
-      "peer": true
+      "license": "Apache-2.0"
     },
     "node_modules/typescript-logging-category-style": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "name": "homebridge-eufy-security",
   "version": "4.4.2-beta.19",
   "description": "Control Eufy Security from homebridge.",
+  "type": "module",
   "license": "Apache-2.0",
   "repository": {
     "type": "git",
@@ -29,7 +30,7 @@
     "build": "npm run build-plugin && npm run postbuild",
     "build-plugin": "rimraf ./dist && tsc",
     "postbuild": "cp -r ./media ./dist/media",
-    "prebuild": "node -p \"'export const LIB_VERSION = ' + JSON.stringify(require('./package.json').version) + ';'\" > src/version.ts",
+    "prebuild": "node --input-type=module -e \"import{readFileSync}from'fs';const p=JSON.parse(readFileSync('./package.json','utf8'));process.stdout.write('export const LIB_VERSION = '+JSON.stringify(p.version)+';\\n');\" > src/version.ts",
     "prepublishOnly": "npm run lint && npm run build"
   },
   "keywords": [

--- a/src/accessories/AutoSyncStationAccessory.ts
+++ b/src/accessories/AutoSyncStationAccessory.ts
@@ -1,8 +1,8 @@
 import { PlatformAccessory } from 'homebridge';
-import { EufySecurityPlatform } from '../platform';
+import { EufySecurityPlatform } from '../platform.js';
 import { AlarmEvent, GuardMode, Station } from 'eufy-security-client';
-import { StationAccessory } from './StationAccessory';
-import { CHAR, SERV, log } from '../utils/utils';
+import { StationAccessory } from './StationAccessory.js';
+import { CHAR, SERV, log } from '../utils/utils.js';
 
 /**
  * Platform Auto Accessory

--- a/src/accessories/BaseAccessory.ts
+++ b/src/accessories/BaseAccessory.ts
@@ -5,10 +5,10 @@ import {
   Service,
   WithUUID,
 } from 'homebridge';
-import { EufySecurityPlatform } from '../platform';
+import { EufySecurityPlatform } from '../platform.js';
 import { DeviceType, DeviceEvents, PropertyValue, Device, Station, StationEvents } from 'eufy-security-client';
 import { EventEmitter } from 'events';
-import { CHAR, SERV, log } from '../utils/utils';
+import { CHAR, SERV, log } from '../utils/utils.js';
 import { ILogObj, Logger } from 'tslog';
 
 /**

--- a/src/accessories/CameraAccessory.ts
+++ b/src/accessories/CameraAccessory.ts
@@ -15,17 +15,17 @@ import {
   AudioRecordingSamplerate,
 } from 'homebridge';
 
-import { EufySecurityPlatform } from '../platform';
-import { DeviceAccessory } from './Device';
+import { EufySecurityPlatform } from '../platform.js';
+import { DeviceAccessory } from './Device.js';
 
  
 // @ts-ignore  
 import { Camera, DeviceEvents, PropertyName, CommandName, StreamMetadata, PropertyValue } from 'eufy-security-client';
 
-import { CameraConfig, DEFAULT_CAMERACONFIG_VALUES } from '../utils/configTypes';
-import { CHAR, SERV } from '../utils/utils';
-import { StreamingDelegate } from '../controller/streamingDelegate';
-import { RecordingDelegate } from '../controller/recordingDelegate';
+import { CameraConfig, DEFAULT_CAMERACONFIG_VALUES } from '../utils/configTypes.js';
+import { CHAR, SERV } from '../utils/utils.js';
+import { StreamingDelegate } from '../controller/streamingDelegate.js';
+import { RecordingDelegate } from '../controller/recordingDelegate.js';
 
 // A semi-complete description of the UniFi Protect camera channel JSON.
 export interface ProtectCameraChannelConfig {

--- a/src/accessories/Device.ts
+++ b/src/accessories/Device.ts
@@ -5,10 +5,10 @@ import {
   Service,
   WithUUID,
 } from 'homebridge';
-import { EufySecurityPlatform } from '../platform';
-import { BaseAccessory } from './BaseAccessory';
+import { EufySecurityPlatform } from '../platform.js';
+import { BaseAccessory } from './BaseAccessory.js';
 import { Device, PropertyName } from 'eufy-security-client';
-import { CHAR, SERV } from '../utils/utils';
+import { CHAR, SERV } from '../utils/utils.js';
 
 export type CharacteristicType = WithUUID<{ new(): Characteristic }>;
 export type ServiceType = WithUUID<typeof Service> | Service;

--- a/src/accessories/EntrySensorAccessory.ts
+++ b/src/accessories/EntrySensorAccessory.ts
@@ -1,11 +1,11 @@
 import { PlatformAccessory } from 'homebridge';
-import { EufySecurityPlatform } from '../platform';
-import { DeviceAccessory } from './Device';
+import { EufySecurityPlatform } from '../platform.js';
+import { DeviceAccessory } from './Device.js';
 
  
 // @ts-ignore  
 import { EntrySensor, PropertyName } from 'eufy-security-client';
-import { CHAR, SERV } from '../utils/utils';
+import { CHAR, SERV } from '../utils/utils.js';
 
 /**
  * EntrySensorAccessory Class

--- a/src/accessories/LockAccessory.ts
+++ b/src/accessories/LockAccessory.ts
@@ -1,10 +1,10 @@
  
 // @ts-ignore
 import { CharacteristicValue, PlatformAccessory } from 'homebridge';
-import { EufySecurityPlatform } from '../platform';
-import { DeviceAccessory } from './Device';
+import { EufySecurityPlatform } from '../platform.js';
+import { DeviceAccessory } from './Device.js';
 import { Lock, PropertyName } from 'eufy-security-client';
-import { CHAR, SERV } from '../utils/utils';
+import { CHAR, SERV } from '../utils/utils.js';
 
 /**
  * LockAccessory Class

--- a/src/accessories/MotionSensorAccessory.ts
+++ b/src/accessories/MotionSensorAccessory.ts
@@ -1,11 +1,11 @@
 import { PlatformAccessory } from 'homebridge';
-import { EufySecurityPlatform } from '../platform';
-import { DeviceAccessory } from './Device';
+import { EufySecurityPlatform } from '../platform.js';
+import { DeviceAccessory } from './Device.js';
 
  
 // @ts-ignore  
 import { MotionSensor, PropertyName } from 'eufy-security-client';
-import { CHAR, SERV } from '../utils/utils';
+import { CHAR, SERV } from '../utils/utils.js';
 
 /**
  * MotionSensorAccessory Class

--- a/src/accessories/StationAccessory.ts
+++ b/src/accessories/StationAccessory.ts
@@ -1,12 +1,12 @@
 import { Characteristic, PlatformAccessory, CharacteristicValue } from 'homebridge';
 
-import { EufySecurityPlatform } from '../platform';
-import { BaseAccessory } from './BaseAccessory';
+import { EufySecurityPlatform } from '../platform.js';
+import { BaseAccessory } from './BaseAccessory.js';
  
 // @ts-ignore  
 import { Station, DeviceType, PropertyName, PropertyValue, AlarmEvent, GuardMode } from 'eufy-security-client';
-import { StationConfig } from '../utils/configTypes';
-import { CHAR, SERV, log } from '../utils/utils';
+import { StationConfig } from '../utils/configTypes.js';
+import { CHAR, SERV, log } from '../utils/utils.js';
 
 export enum HKGuardMode {
   STAY_ARM = 0,

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,6 @@
 import { PlatformConfig } from 'homebridge';
 
-import { CameraConfig, StationConfig } from './utils/configTypes';
+import { CameraConfig, StationConfig } from './utils/configTypes.js';
 
 /**
  * HomebridgePlatform

--- a/src/controller/LocalLivestreamManager.ts
+++ b/src/controller/LocalLivestreamManager.ts
@@ -1,7 +1,7 @@
 import { Readable } from 'stream';
 import { Station, Device, StreamMetadata, EufySecurity } from 'eufy-security-client';
-import { CameraAccessory } from '../accessories/CameraAccessory';
-import { Deferred } from '../utils/utils';
+import { CameraAccessory } from '../accessories/CameraAccessory.js';
+import { Deferred } from '../utils/utils.js';
 import { ILogObj, Logger } from 'tslog';
 
 /** Internal state: streams plus a timestamp for dedup/reuse logic. */

--- a/src/controller/recordingDelegate.ts
+++ b/src/controller/recordingDelegate.ts
@@ -9,12 +9,12 @@ import {
   PlatformAccessory,
   RecordingPacket,
 } from 'homebridge';
-import { EufySecurityPlatform } from '../platform';
-import { CameraConfig, VideoConfig } from '../utils/configTypes';
-import { FFmpeg, FFmpegParameters } from '../utils/ffmpeg';
+import { EufySecurityPlatform } from '../platform.js';
+import { CameraConfig, VideoConfig } from '../utils/configTypes.js';
+import { FFmpeg, FFmpegParameters } from '../utils/ffmpeg.js';
 import net from 'net';
-import { CHAR, SERV, isRtspReady, log } from '../utils/utils';
-import { LocalLivestreamManager } from './LocalLivestreamManager';
+import { CHAR, SERV, isRtspReady, log } from '../utils/utils.js';
+import { LocalLivestreamManager } from './LocalLivestreamManager.js';
 
 const MAX_RECORDING_MINUTES = 1; // should never be used
 
@@ -151,7 +151,7 @@ export class RecordingDelegate implements CameraRecordingDelegate {
         }, maxDuration * 1000);
       }
 
-      yield* this.generateFragments(this.session.generator);
+      yield* this.generateFragments(this.session!.generator);
     } catch (error) {
       if (!this.handlingStreamingRequest && this.closeReason && this.closeReason === HDSProtocolSpecificErrorReason.CANCELLED) {
         log.debug(this.camera.getName(),

--- a/src/controller/snapshotDelegate.ts
+++ b/src/controller/snapshotDelegate.ts
@@ -5,7 +5,7 @@ import { Camera, Device, DeviceEvents, Picture, PropertyName } from 'eufy-securi
 import { SnapshotRequest } from 'homebridge';
 import { ILogObj, Logger } from 'tslog';
 
-import { CameraAccessory } from '../accessories/CameraAccessory';
+import { CameraAccessory } from '../accessories/CameraAccessory.js';
 import {
   SNAPSHOT_CACHE_BALANCED_SECONDS,
   SNAPSHOT_CACHE_FRESH_SECONDS,
@@ -13,19 +13,25 @@ import {
   SNAPSHOT_FETCH_TIMEOUT_MS,
   SNAPSHOT_MIN_REFRESH_INTERVAL_MINUTES,
   SNAPSHOT_RING_DEBOUNCE_SECONDS,
-} from '../settings';
-import { CameraConfig, SnapshotHandlingMethod } from '../utils/configTypes';
-import { FFmpeg, FFmpegParameters } from '../utils/ffmpeg';
-import { isRtspReady } from '../utils/utils';
-import { LocalLivestreamManager } from './LocalLivestreamManager';
+} from '../settings.js';
+import { CameraConfig, SnapshotHandlingMethod } from '../utils/configTypes.js';
+import { FFmpeg, FFmpegParameters } from '../utils/ffmpeg.js';
+import { isRtspReady } from '../utils/utils.js';
+import { LocalLivestreamManager } from './LocalLivestreamManager.js';
 
 type PlaceholderKey = 'black' | 'unavailable' | 'offline' | 'disabled';
 
+import { fileURLToPath } from 'url';
+import path from 'path';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
 const PLACEHOLDER_PATHS: Record<PlaceholderKey, string> = {
-  offline: require.resolve('../../media/camera-offline.png'),
-  disabled: require.resolve('../../media/camera-disabled.png'),
-  black: require.resolve('../../media/Snapshot-black.png'),
-  unavailable: require.resolve('../../media/Snapshot-Unavailable.png'),
+  offline: path.resolve(__dirname, '../../media/camera-offline.png'),
+  disabled: path.resolve(__dirname, '../../media/camera-disabled.png'),
+  black: path.resolve(__dirname, '../../media/Snapshot-black.png'),
+  unavailable: path.resolve(__dirname, '../../media/Snapshot-Unavailable.png'),
 };
 
 type Snapshot = {

--- a/src/controller/streamingDelegate.ts
+++ b/src/controller/streamingDelegate.ts
@@ -17,13 +17,13 @@ import { Logger, ILogObj } from 'tslog';
 import { pickPort } from 'pick-port';
 import { Camera, PropertyName } from 'eufy-security-client';
 
-import { CameraAccessory } from '../accessories/CameraAccessory';
-import { SessionInfo, VideoConfig } from '../utils/configTypes';
-import { FFmpeg, FFmpegParameters } from '../utils/ffmpeg';
-import { TalkbackStream } from '../utils/Talkback';
-import { HAP, isRtspReady } from '../utils/utils';
-import { LocalLivestreamManager } from './LocalLivestreamManager';
-import { snapshotDelegate } from './snapshotDelegate';
+import { CameraAccessory } from '../accessories/CameraAccessory.js';
+import { SessionInfo, VideoConfig } from '../utils/configTypes.js';
+import { FFmpeg, FFmpegParameters } from '../utils/ffmpeg.js';
+import { TalkbackStream } from '../utils/Talkback.js';
+import { HAP, isRtspReady } from '../utils/utils.js';
+import { LocalLivestreamManager } from './LocalLivestreamManager.js';
+import { snapshotDelegate } from './snapshotDelegate.js';
 
 type ActiveSession = {
   videoProcess?: FFmpeg;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,13 +1,13 @@
 import { API } from 'homebridge';
 
-import { PLATFORM_NAME, PLUGIN_NAME } from './settings';
-import { EufySecurityPlatform } from './platform';
-import { setHap } from './utils/utils';
+import { PLATFORM_NAME, PLUGIN_NAME } from './settings.js';
+import { EufySecurityPlatform } from './platform.js';
+import { setHap } from './utils/utils.js';
 
 /**
  * This method registers the platform with Homebridge
  */
-export = (api: API) => {
+export default (api: API) => {
   setHap(api.hap);
   api.registerPlatform(PLUGIN_NAME, PLATFORM_NAME, EufySecurityPlatform);
 };

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -6,18 +6,18 @@ import {
   APIEvent,
 } from 'homebridge';
 
-import { PLATFORM_NAME, PLUGIN_NAME } from './settings';
+import { PLATFORM_NAME, PLUGIN_NAME } from './settings.js';
 
-import { DEFAULT_CONFIG_VALUES, EufySecurityPlatformConfig } from './config';
+import { DEFAULT_CONFIG_VALUES, EufySecurityPlatformConfig } from './config.js';
 
-import { DeviceIdentifier, StationContainer, DeviceContainer } from './interfaces';
+import { DeviceIdentifier, StationContainer, DeviceContainer } from './interfaces.js';
 
-import { StationAccessory } from './accessories/StationAccessory';
-import { EntrySensorAccessory } from './accessories/EntrySensorAccessory';
-import { MotionSensorAccessory } from './accessories/MotionSensorAccessory';
-import { CameraAccessory } from './accessories/CameraAccessory';
-import { LockAccessory } from './accessories/LockAccessory';
-import { AutoSyncStationAccessory } from './accessories/AutoSyncStationAccessory';
+import { StationAccessory } from './accessories/StationAccessory.js';
+import { EntrySensorAccessory } from './accessories/EntrySensorAccessory.js';
+import { MotionSensorAccessory } from './accessories/MotionSensorAccessory.js';
+import { CameraAccessory } from './accessories/CameraAccessory.js';
+import { LockAccessory } from './accessories/LockAccessory.js';
+import { AutoSyncStationAccessory } from './accessories/AutoSyncStationAccessory.js';
 
 import {
   EufySecurity,
@@ -43,8 +43,8 @@ import os from 'node:os';
 import { platform } from 'node:process';
 import { readFileSync } from 'node:fs';
 
-import { initLog, log, tsLogger, ffmpegLogger, HAP } from './utils/utils';
-import { LIB_VERSION } from './version';
+import { initLog, log, tsLogger, ffmpegLogger, HAP } from './utils/utils.js';
+import { LIB_VERSION } from './version.js';
 
 export class EufySecurityPlatform implements DynamicPlatformPlugin {
   public eufyClient: EufySecurity = {} as EufySecurity;

--- a/src/utils/Talkback.ts
+++ b/src/utils/Talkback.ts
@@ -1,8 +1,8 @@
 import { Duplex, Writable } from 'stream';
 
-import { EufySecurityPlatform } from '../platform';
+import { EufySecurityPlatform } from '../platform.js';
 import { Device, EufySecurity, Station } from 'eufy-security-client';
-import { log } from './utils';
+import { log } from './utils.js';
 
 export class TalkbackStream extends Duplex {
 

--- a/src/utils/ffmpeg.ts
+++ b/src/utils/ffmpeg.ts
@@ -7,7 +7,7 @@ import ffmpegPath from 'ffmpeg-for-homebridge';
 import { pickPort } from 'pick-port';
 
 import EventEmitter from 'events';
-import { CameraConfig, VideoConfig } from './configTypes';
+import { CameraConfig, VideoConfig } from './configTypes.js';
 import {
     AudioRecordingCodecType,
     AudioRecordingSamplerate,
@@ -19,8 +19,8 @@ import {
     SnapshotRequest,
     StartStreamRequest,
 } from 'homebridge';
-import { SessionInfo } from './configTypes';
-import { ffmpegLogger } from './utils';
+import { SessionInfo } from './configTypes.js';
+import { ffmpegLogger } from './utils.js';
 
 class FFmpegProgress extends EventEmitter {
     private server: net.Server;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -3,7 +3,7 @@ import { Logger, ILogObj } from 'tslog';
 import { HAP as HAPHB } from 'homebridge';
 import type { Characteristic, Service } from 'homebridge';
 
-import { CameraConfig } from './configTypes';
+import { CameraConfig } from './configTypes.js';
 import { Camera, PropertyName } from 'eufy-security-client';
 
 export let HAP!: HAPHB;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,19 +1,26 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "commonjs",
-    "lib": [
-      "es2022"
-    ],
-    "sourceMap": true,
-    "outDir": "./dist",
-    "rootDir": "./src",
-    "strict": true,
+    /* Base Options */
     "esModuleInterop": true,
+    "skipLibCheck": true,
+    "target": "es2022",
+    "allowJs": true,
+    "resolveJsonModule": true,
+    "moduleDetection": "force",
+
+    /* Strictness */
+    "strict": true,
     "noImplicitAny": false,
-    "skipLibCheck": true
+    "noImplicitOverride": true,
+
+    /* Transpiling with TypeScript */
+    "module": "NodeNext",
+    "outDir": "dist",
+    "rootDir": "src",
+    "sourceMap": true,
+
+    /* Not running in the DOM */
+    "lib": ["es2022"]
   },
-  "include": [
-    "src/"
-  ]
+  "include": ["src/"]
 }


### PR DESCRIPTION
## Why

Node.js emits a `MODULE_TYPELESS_PACKAGE_JSON` warning at every startup because the plugin's module format is unspecified. Node has to parse each file twice — first as CommonJS, then re-parse as ESM after detecting module syntax — adding unnecessary overhead on every boot.

## What this achieves

- **Eliminates the runtime warning** by declaring the project as an ES module
- **Improves startup performance** by removing the double-parse overhead
- **Aligns with the ecosystem** — Node.js, TypeScript, and the broader JavaScript ecosystem are converging on ESM as the standard module format
- **Refreshes the TypeScript configuration** following current best practices for Node.js ESM projects, adding useful compiler options like `resolveJsonModule`, `moduleDetection`, and `noImplicitOverride`
- **Ensures forward compatibility** with future Node.js versions that may deprecate the fallback behavior entirely
