### PR TITLE
feat: cache characteristic values — eliminate redundant HomeKit polling

### DIFF
--- a/src/accessories/BaseAccessory.ts
+++ b/src/accessories/BaseAccessory.ts
@@ -1,3 +1,6 @@
+// Servicing and caching strategy inspired 
+// by homebridge-ring — https://github.com/dgreif/ring
+
 import {
   PlatformAccessory,
   Characteristic,


### PR DESCRIPTION
## Summary

HomeKit polls every characteristic roughly every 10 seconds. Until now each poll triggered a full `onGet` → `getValue()` round-trip back into the eufy-security-client, even though the client already pushes property updates in real-time.

This PR switches to a **cache-first, push-refresh** model: characteristic values are seeded once at registration and then kept fresh exclusively through the existing push events (`property changed`, `onSimpleValue`, `onValue`, `onMultipleValue`). No `onGet` handler is registered, so HomeKit polls return the last cached value at zero cost.

## Motivation

- **Eliminate redundant work** — ~10 s polling × N characteristics was re-fetching data we already had.
- **Lower latency for state changes** — values reach HomeKit as soon as the device pushes them, not on the next poll cycle.
- **Reduce load on eufy cloud / local API** — fewer unnecessary reads.

## How it works

1. **Seed at registration** — `getValue()` is called once, the result is stored via `characteristic.updateValue()`.
2. **Push events** — `onSimpleValue`, `onValue`, and `onMultipleValue` continue calling `updateValue()` as before.
3. **Property-changed refresh** — a global `device.on('property changed')` listener re-evaluates every registered `getValue` and pushes `updateValue()` only when the value has actually changed (distinct-until-changed pattern).

## Breaking changes

None. The `registerCharacteristic` API signature is unchanged; all existing call sites work without modification.

## Inspired by

[homebridge-ring](https://github.com/dgreif/ring/tree/main/packages/homebridge-ring) which uses an RxJS `shareReplay(1)` + `distinctUntilChanged` caching strategy. This implementation achieves the same result using the existing EventEmitter pattern from eufy-security-client.
