### PR TITLE
fix: Prevent crash when storage directory is missing

### DIFF
--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -97,7 +97,7 @@ class UiServer extends HomebridgePluginUiServer {
 
   initTransportStreams() {
     if (!fs.existsSync(this.storagePath)) {
-      fs.mkdirSync(this.storagePath);
+      fs.mkdirSync(this.storagePath, { recursive: true });
     }
     const pluginLogStream = createStream('configui-server.log', { path: this.storagePath, interval: '1d', rotate: 3, maxSize: '200M' });
     const pluginLogLibStream = createStream('configui-lib.log', { path: this.storagePath, interval: '1d', rotate: 3, maxSize: '200M' });
@@ -478,6 +478,9 @@ class UiServer extends HomebridgePluginUiServer {
   }
 
   storeAccessories() {
+    if (!fs.existsSync(this.storagePath)) {
+      fs.mkdirSync(this.storagePath, { recursive: true });
+    }
     const dataToStore = { version: LIB_VERSION, storedAt: new Date().toISOString(), stations: this.stations };
     fs.writeFileSync(this.storedAccessories_file, JSON.stringify(dataToStore));
   }


### PR DESCRIPTION
### Problem

The Homebridge UI server crashes with an `ENOENT` error when writing the accessories cache file if the `eufysecurity` storage directory does not yet exist. This can happen when:

- The plugin runs for the first time on a fresh install
- The storage directory was manually deleted or cleaned up (e.g. via "Reset Plugin")
- The `storeAccessories()` method is called before `initTransportStreams()` has had a chance to create the directory

### Solution

Ensure the storage directory is created (recursively) before any file write operation, so the plugin gracefully handles a missing directory instead of crashing.

### Impact

- Eliminates `ENOENT` errors during accessory discovery on fresh or reset installations
- No functional change for users whose storage directory already exists
