### PR TITLE
fix(ui): resolve ReferenceError during device discovery

### DIFF
--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -441,7 +441,7 @@ class UiServer extends HomebridgePluginUiServer {
         typename: DeviceType[devType],
         standalone: device.getSerial() === device.getStationSerial(),
         hasBattery: device.hasBattery(),
-        isCamera: device.isCamera() || Device.isLockWifiVideo(type),
+      isCamera: device.isCamera() || Device.isLockWifiVideo(devType),
         isDoorbell: device.isDoorbell(),
         isKeypad: device.isKeyPad(),
         isMotionSensor: Device.isMotionSensor(devType),


### PR DESCRIPTION
## Summary

Fixes a `ReferenceError: type is not defined` crash during device discovery in the Homebridge UI.

## Problem

When processing discovered devices in `processPendingAccessories`, the `isCamera` property check called `Device.isLockWifiVideo(type)` — but `type` does not exist in that scope. The correct variable is `devType`, declared a few lines above.

This caused the entire discovery batch to fail, preventing all devices from appearing in the UI after login or refresh.

## Fix

Replace the undefined `type` reference with the correct `devType` variable.
