### PR TITLE
feat(ui): device card power indicators and inline toggle

### DIFF
--- a/homebridge-ui/public/style.css
+++ b/homebridge-ui/public/style.css
@@ -304,10 +304,20 @@
   text-overflow: ellipsis;
 }
 
+.device-card__meta-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+
 .device-card__meta {
   font-size: 0.75rem;
   color: var(--eufy-muted);
-  margin-bottom: 8px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
 }
 
 .device-card__footer {

--- a/homebridge-ui/public/views/dashboard.js
+++ b/homebridge-ui/public/views/dashboard.js
@@ -132,6 +132,7 @@ const DashboardView = {
             typename: station.typename,
             unsupported: station.unsupported,
             ignored: station.ignored,
+            power: station.power,
           };
           if (station.unsupported) {
             unsupported.push({ item: stationItem, isStation: true, station });


### PR DESCRIPTION
## Device card UI improvements

### Changes

- **Toggle inline with battery**: The enable/disable toggle is now on the same line as the battery indicator, making the card more compact.
- **Power source indicators**: All device types now show their power source — battery percentage, battery low, solar, charging, or plugged in — using appropriate icons (bolt, solar panel, battery level).
- **Centralized power logic**: Battery and power source detection is now computed server-side (`_computePower`) using `powerSource` and `chargingStatus` bitmask from eufy-security-client, so the UI simply renders pre-computed data.
- **Station power status**: Stations now also display their power status on the dashboard card.
- **Sensor battery support**: Entry sensors and motion sensors that only expose `batteryLow` (without a percentage) now correctly show battery status.
