### PR TITLE
fix: handle async rejections in livestream start/stop

### DIFF
--- a/src/controller/LocalLivestreamManager.ts
+++ b/src/controller/LocalLivestreamManager.ts
@@ -85,12 +85,10 @@ export class LocalLivestreamManager {
 
     this.pending = { deferred, timer };
 
-    try {
-      this.eufyClient.startStationLivestream(this.serialNumber);
-    } catch (err) {
-      this.log.error(`startStationLivestream threw: ${err}`);
+    this.eufyClient.startStationLivestream(this.serialNumber).catch((err) => {
+      this.log.error(`startStationLivestream failed: ${err}`);
       this.settlePending('reject', err);
-    }
+    });
 
     return deferred.promise;
   }
@@ -117,7 +115,9 @@ export class LocalLivestreamManager {
 
   public stopLocalLiveStream(): void {
     this.log.debug('Stopping station livestream.');
-    this.eufyClient.stopStationLivestream(this.serialNumber);
+    this.eufyClient.stopStationLivestream(this.serialNumber).catch((err) => {
+      this.log.warn(`stopStationLivestream failed: ${err}`);
+    });
     this.destroyStreams();
   }
 


### PR DESCRIPTION
## Summary

Fixes an unhandled promise rejection in `LocalLivestreamManager` that crashes the child bridge when `eufy-security-client` rejects `startStationLivestream()` or `stopStationLivestream()`.

## Problem

Both `startStationLivestream()` and `stopStationLivestream()` are async and return Promises. The existing code wrapped the start call in a sync `try/catch` without `await`, which does not catch async rejections. When `eufy-security-client` throws a `NotSupportedError` (e.g. for an Indoor Cam S350 / T8417), the rejection goes unhandled and kills the child bridge process (exit code 1).

The stop call had no error handling at all, meaning a rejection during cleanup would cause a second crash.

## Fix

- Replace the sync `try/catch` around `startStationLivestream()` with `.catch()` on the returned Promise, properly routing errors through `settlePending('reject', err)`
- Add `.catch()` to `stopStationLivestream()` to log and swallow errors during cleanup
