### PR TITLE
fix: share servicesInUse across stacked accessories to prevent pruning

### DIFF
--- a/src/accessories/BaseAccessory.ts
+++ b/src/accessories/BaseAccessory.ts
@@ -327,12 +327,12 @@ export abstract class BaseAccessory extends EventEmitter {
     // CameraController creates these automatically during configureController()
     // and they are not tracked in servicesInUse.
     const safeServiceUUIDs = [
-      SERV.CameraRTPStreamManagement.UUID,      // 00000110
-      '0000021A-0000-1000-8000-0026BB765291',    // CameraOperatingMode (HKSV)
-      '00000204-0000-1000-8000-0026BB765291',    // CameraRecordingManagement (HKSV)
-      '00000129-0000-1000-8000-0026BB765291',    // DataStreamTransportManagement (HKSV)
-      SERV.Microphone.UUID,                      // 00000112 (created by CameraController)
-      SERV.Speaker.UUID,                         // 00000113 (created by CameraController)
+      SERV.CameraRTPStreamManagement.UUID,
+      SERV.CameraOperatingMode.UUID,
+      SERV.CameraRecordingManagement.UUID,
+      SERV.DataStreamTransportManagement.UUID,
+      SERV.Microphone.UUID,
+      SERV.Speaker.UUID,
     ];
 
     this.accessory.services.forEach((service) => {

--- a/src/accessories/CameraAccessory.ts
+++ b/src/accessories/CameraAccessory.ts
@@ -490,8 +490,8 @@ export class CameraAccessory extends DeviceAccessory {
       // accessory already has them (e.g. from a previous run), configureController
       // will throw a duplicate UUID error.
       const controllerManagedServiceUUIDs = [
-        '0000021A-0000-1000-8000-0026BB765291', // CameraOperatingMode
-        '00000129-0000-1000-8000-0026BB765291', // DataStreamTransportManagement
+        SERV.CameraOperatingMode.UUID,
+        SERV.DataStreamTransportManagement.UUID,
       ];
       for (const uuid of controllerManagedServiceUUIDs) {
         const existingService = this.accessory.services.find(s => s.UUID === uuid);


### PR DESCRIPTION
## Problem

When a device stacks multiple accessory types on the same `PlatformAccessory` (e.g. the T8530 which is both a Lock and a Camera), each `BaseAccessory` subclass maintained its own independent `servicesInUse` array. The last constructor to call `pruneUnusedServices()` would remove services registered by earlier constructors, because they weren't in its own list.

For the T8530: `LockAccessory` registers Lock services, then `CameraAccessory` prunes them because they're not in CameraAccessory's `servicesInUse`.

## Fix

- **Shared `servicesInUse`**: All `BaseAccessory` instances on the same `PlatformAccessory` now share a single `servicesInUse` array (stored on the accessory context). This way, pruning from any accessor sees all registered services.
- **Replace hardcoded UUIDs with `SERV` constants**: The `safeServiceUUIDs` list in `pruneUnusedServices()` and the stale-service removal in `CameraAccessory` now use `SERV.CameraOperatingMode.UUID`, `SERV.CameraRecordingManagement.UUID`, and `SERV.DataStreamTransportManagement.UUID` instead of raw UUID strings.


Credit to @kats1123 for identifying the root cause.