### PR TITLE
fix: guard isConnected calls to prevent TypeError during early shutdown

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -450,12 +450,12 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
 
     try {
       await this.eufyClient.connect();
-      log.debug('EufyClient connected ' + this.eufyClient.isConnected());
+      log.debug('EufyClient connected ' + this.eufyClient?.isConnected?.());
     } catch (e) {
       log.error(`Error authenticating Eufy: ${e}`);
     }
 
-    if (!this.eufyClient.isConnected()) {
+    if (!this.eufyClient?.isConnected?.()) {
       log.error('Not connected can\'t continue!');
       return;
     }
@@ -788,7 +788,7 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
     this.accessoriesStore?.cancelPending();
 
     try {
-      if (this.eufyClient.isConnected()) {
+      if (this.eufyClient?.isConnected?.()) {
         this.eufyClient.close();
       }
       log.info('Finished shutdown!');


### PR DESCRIPTION
## Problem

When Homebridge shuts down before the `EufySecurity` client has fully initialized, calling `this.eufyClient.isConnected()` throws a `TypeError` because `eufyClient` is still an empty object (`{} as EufySecurity`) — it hasn't been replaced by the real instance from `EufySecurity.initialize()` yet.

```
Error while shutdown: TypeError: this.eufyClient.isConnected is not a function
```

## Fix

Use optional chaining (`this.eufyClient?.isConnected?.()`) on all unguarded `isConnected()` calls in `platform.ts`, matching the pattern already used in `accessoriesStore.ts`. This safely returns `undefined` (falsy) when the client isn't initialized, allowing shutdown and connection checks to proceed without errors.
