### PR TITLE
fix: bump version to 4.4.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@homebridge-plugins/homebridge-eufy-security",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@homebridge-plugins/homebridge-eufy-security",
-      "version": "4.4.2",
+      "version": "4.4.3",
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Eufy Security",
   "name": "@homebridge-plugins/homebridge-eufy-security",
-  "version": "4.4.2",
+  "version": "4.4.3",
   "description": "Control Eufy Security from homebridge.",
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary

This bumps the version to `4.4.3` in `package.json` and `package-lock.json`.