### PR TITLE
fix: BaseAccessory quality improvements

### DIFF
--- a/src/accessories/BaseAccessory.ts
+++ b/src/accessories/BaseAccessory.ts
@@ -149,12 +149,11 @@ export abstract class BaseAccessory extends EventEmitter {
     // without requiring HomeKit to poll through onGet.
     this.device.on('property changed', this.refreshCachedValues.bind(this));
 
-    this.logPropertyKeys();
+    this.logDeviceProperties();
   }
 
-  // Function to extract and log keys
-  private logPropertyKeys() {
-    this.log.debug(`Property Keys:`, this.device.getProperties());
+  private logDeviceProperties() {
+    this.log.debug(`Device Properties:`, this.device.getProperties());
   }
 
   /**


### PR DESCRIPTION
Quality improvements to `BaseAccessory.ts` — no functional behaviour changes for end users.

### Fixes
- **Typo**: corrected `'Unknowm'` → `'Unknown'` in all five accessory info fallback values
- **Type guard**: `isServiceInstance` now checks for `characteristics` property instead of relying on a weak `typeof === 'object'` test that could match `null` or unrelated objects
- **Floating promise**: `onSet` handler now properly `await`s `setValue` so rejections propagate instead of being silently lost

### Improvements
- Cache refresh errors are now logged at debug level instead of being swallowed by an empty `catch {}`
- Magic number `30` for `setMaxListeners` extracted into `MAX_DEVICE_LISTENERS` static constant
- Camera controller safe-service UUIDs hoisted into a static `Set` for O(1) lookups and single allocation
- Renamed `logPropertyKeys` → `logDeviceProperties` (it logs full properties, not just keys)
