### PR TITLE
chore: use native tar.gz compression for diagnostics

### DIFF
--- a/homebridge-ui/public/views/diagnostics.js
+++ b/homebridge-ui/public/views/diagnostics.js
@@ -202,7 +202,7 @@ const DiagnosticsView = {
     try {
       const result = await Api.downloadDiagnostics();
       const rawBuffer = result.buffer || result;
-      const filename = result.filename || 'eufy-security-diagnostics.zip';
+      const filename = result.filename || 'eufy-security-diagnostics.tar.gz';
       const bytes = new Uint8Array(rawBuffer.data || rawBuffer);
       let binary = '';
       for (let i = 0; i < bytes.length; i++) {
@@ -210,7 +210,7 @@ const DiagnosticsView = {
       }
       const base64 = btoa(binary);
       const a = document.createElement('a');
-      a.href = 'data:application/zip;base64,' + base64;
+      a.href = 'data:application/gzip;base64,' + base64;
       a.download = filename;
       document.body.appendChild(a);
       a.click();

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -2,7 +2,7 @@ import { EufySecurity, libVersion, Device, PropertyName, CommandName, DeviceType
 import * as fs from 'fs';
 import { Logger as TsLogger } from 'tslog';
 import { createStream } from 'rotating-file-stream';
-import { Zip } from 'zip-lib';
+import { create as tarCreate } from 'tar';
 import { HomebridgePluginUiServer } from '@homebridge/plugin-ui-utils';
 import path from 'path';
 import { fileURLToPath } from 'url';
@@ -22,7 +22,7 @@ class UiServer extends HomebridgePluginUiServer {
   tsLog;
   storagePath;
   storedAccessories_file;
-  diagnosticsZipFilePath;
+  diagnosticsArchivePath;
 
   adminAccountUsed = false;
 
@@ -65,7 +65,7 @@ class UiServer extends HomebridgePluginUiServer {
     this.storagePath = this.homebridgeStoragePath + '/eufysecurity';
     this.storedAccessories_file = this.storagePath + '/accessories.json';
     this.unsupported_file = this.storagePath + '/unsupported.json';
-    this.diagnosticsZipFilePath = null;
+    this.diagnosticsArchivePath = null;
     this.config.persistentDir = this.storagePath;
 
     this.initLogger();
@@ -1178,45 +1178,37 @@ class UiServer extends HomebridgePluginUiServer {
     this.pushEvent('diagnosticsProgress', { progress: 10, status: 'Collecting log files' });
     const finalLogFiles = await this.getLogFiles();
 
-    this.pushEvent('diagnosticsProgress', { progress: 30, status: 'Adding files to archive' });
-    const zip = new Zip();
-    let numberOfFiles = 0;
-    finalLogFiles.forEach(logFile => {
-      const filePath = path.join(this.storagePath, logFile);
-      zip.addFile(filePath);
-      numberOfFiles++;
-    });
+    this.pushEvent('diagnosticsProgress', { progress: 30, status: 'Collecting diagnostic files' });
+    const filesToArchive = [...finalLogFiles];
 
     // Include accessories.json for diagnostics
     if (fs.existsSync(this.storedAccessories_file)) {
-      zip.addFile(this.storedAccessories_file);
-      numberOfFiles++;
+      filesToArchive.push(path.basename(this.storedAccessories_file));
     }
 
     // Include unsupported.json for diagnostics
     if (fs.existsSync(this.unsupported_file)) {
-      zip.addFile(this.unsupported_file);
-      numberOfFiles++;
+      filesToArchive.push(path.basename(this.unsupported_file));
     }
 
     this.pushEvent('diagnosticsProgress', { progress: 40, status: 'Checking archive content' });
-    if (numberOfFiles === 0) {
+    if (filesToArchive.length === 0) {
       throw new Error('No diagnostic files were found');
     }
 
     try {
       const now = new Date();
       const timestamp = now.toISOString().replace(/[:T]/g, '-').replace(/\..+/, '');
-      this.diagnosticsZipFilePath = path.join(this.storagePath, `diagnostics-${timestamp}.zip`);
+      this.diagnosticsArchivePath = path.join(this.storagePath, `diagnostics-${timestamp}.tar.gz`);
 
-      this.pushEvent('diagnosticsProgress', { progress: 45, status: `Compressing ${numberOfFiles} files` });
-      await zip.archive(this.diagnosticsZipFilePath);
+      this.pushEvent('diagnosticsProgress', { progress: 45, status: `Compressing ${filesToArchive.length} files` });
+      await tarCreate({ gzip: true, file: this.diagnosticsArchivePath, cwd: this.storagePath }, filesToArchive);
 
       this.pushEvent('diagnosticsProgress', { progress: 80, status: 'Reading content' });
-      const fileBuffer = fs.readFileSync(this.diagnosticsZipFilePath);
+      const fileBuffer = fs.readFileSync(this.diagnosticsArchivePath);
 
-      this.pushEvent('diagnosticsProgress', { progress: 90, status: 'Returning zip file' });
-      return { buffer: fileBuffer, filename: path.basename(this.diagnosticsZipFilePath) };
+      this.pushEvent('diagnosticsProgress', { progress: 90, status: 'Returning archive' });
+      return { buffer: fileBuffer, filename: path.basename(this.diagnosticsArchivePath) };
     } catch (error) {
       this.log.error('Error while generating diagnostics archive: ' + error);
       throw error;
@@ -1227,8 +1219,8 @@ class UiServer extends HomebridgePluginUiServer {
 
   removeDiagnosticsArchive() {
     try {
-      if (fs.existsSync(this.diagnosticsZipFilePath)) {
-        fs.unlinkSync(this.diagnosticsZipFilePath);
+      if (fs.existsSync(this.diagnosticsArchivePath)) {
+        fs.unlinkSync(this.diagnosticsArchivePath);
       }
       return true;
     } catch {

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,8 +20,8 @@
         "ffmpeg-for-homebridge": "2.2.1",
         "pick-port": "^2.2.0",
         "rotating-file-stream": "^3.2.9",
-        "tslog": "^4.10.2",
-        "zip-lib": "^1.2.1"
+        "tar": "^7.5.9",
+        "tslog": "^4.10.2"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.3",
@@ -900,15 +900,6 @@
       "dependencies": {
         "base64-js": "^1.3.1",
         "ieee754": "^1.2.1"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -2655,12 +2646,6 @@
         "url": "https://github.com/sponsors/Borewit"
       }
     },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT"
-    },
     "node_modules/pick-port": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pick-port/-/pick-port-2.2.0.tgz",
@@ -3534,37 +3519,6 @@
         "node": ">=18"
       }
     },
-    "node_modules/yauzl": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-3.2.0.tgz",
-      "integrity": "sha512-Ow9nuGZE+qp1u4JIPvg+uCiUr7xGQWdff7JQSk5VGYTAZMDe2q8lxJ10ygv10qmSj031Ty/6FNJpLO4o1Sgc+w==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "pend": "~1.2.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/yazl": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/yazl/-/yazl-3.3.1.tgz",
-      "integrity": "sha512-BbETDVWG+VcMUle37k5Fqp//7SDOK2/1+T7X8TD96M3D9G8jK5VLUdQVdVjGi8im7FGkazX7kk5hkU8X4L5Bng==",
-      "license": "MIT",
-      "dependencies": {
-        "buffer-crc32": "^1.0.0"
-      }
-    },
-    "node_modules/yazl/node_modules/buffer-crc32": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
-      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.0.0"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -3576,19 +3530,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/zip-lib": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/zip-lib/-/zip-lib-1.2.1.tgz",
-      "integrity": "sha512-7MT4fvAoEJPxB/TILqapSpZlJQk5gH29NzhU4ySWXRauXh290KnHK/QkOggL9jmN92H31fv+lkbFIaFKb78ySg==",
-      "license": "MIT",
-      "dependencies": {
-        "yauzl": "^3.2.0",
-        "yazl": "^3.3.1"
-      },
-      "engines": {
-        "node": ">=20"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "tslog": "^4.10.2",
     "rotating-file-stream": "^3.2.9",
     "pick-port": "^2.2.0",
-    "zip-lib": "^1.2.1"
+    "tar": "^7.5.9"
   },
   "devDependencies": {
     "typescript": "^5.9.3",


### PR DESCRIPTION
## Summary

- Replace `zip-lib` (+ `yauzl`, `yazl`) with the `tar` npm package for diagnostics archive generation
- Diagnostics are now downloaded as `.tar.gz` instead of `.zip`
- The `tar` package uses Node.js built-in `node:zlib` for gzip compression — fully cross-platform (Linux, macOS, Windows)
- Drops 6 packages from the dependency tree

## Test plan

- [x] Trigger diagnostics download from the Homebridge UI
- [x] Verify the downloaded file is a valid `.tar.gz` archive
- [x] Verify archive contains log files, accessories.json, and unsupported.json
