### PR TITLE
chore: pin eufy-security-client to ^3.8.0 for release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/plugin-ui-utils": "^2.2.0",
-        "eufy-security-client": "dev",
+        "eufy-security-client": "^3.8.0",
         "ffmpeg-for-homebridge": "2.2.1",
         "pick-port": "^2.2.0",
         "rotating-file-stream": "^3.2.9",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "camera"
   ],
   "dependencies": {
-    "eufy-security-client": "dev",
+    "eufy-security-client": "^3.8.0",
     "@homebridge/plugin-ui-utils": "^2.2.0",
     "ffmpeg-for-homebridge": "2.2.1",
     "tslog": "^4.10.2",


### PR DESCRIPTION
## Summary

- Bump plugin version from 4.4.5 to 4.5.0
- Pin eufy-security-client to ^3.8.0 (minor version bump from 3.7.x)
- Update devDependencies (typescript-eslint, @types/node)
