### PR TITLE
Retry cloud connection on startup before shutting down

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -467,9 +467,8 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
       this.eufyClient.on('close', () => {
         log.debug('Closed!');
       });
-      this.eufyClient.on('connection error', async (error: Error) => {
-        log.debug(`Error: ${error}`);
-        await this.pluginShutdown();
+      this.eufyClient.on('connection error', (error: Error) => {
+        log.warn(`Connection error: ${error}`);
       });
       this.eufyClient.once('captcha request', async () => {
         log.error(`


### PR DESCRIPTION
Improve plugin resilience to network issues at startup and at runtime.

- When the Eufy cloud API is unreachable at startup (e.g. DNS failure), retry up to 3 times with a 30-second delay before shutting down
- Stop immediately shutting down on runtime connection errors — the client library already has built-in reconnection logic (up to 3 retries on API close, exponential backoff on P2P). Let it handle transient outages instead of killing the plugin
- Updated captcha and 2FA messages to direct users to the plugin UI to complete verification
