### PR TITLE
feat: improve HKSV recording reliability

### DIFF
--- a/src/controller/recordingDelegate.ts
+++ b/src/controller/recordingDelegate.ts
@@ -18,6 +18,8 @@ import { LocalLivestreamManager } from './LocalLivestreamManager.js';
 import { snapshotDelegate } from './snapshotDelegate.js';
 
 const MAX_RECORDING_MINUTES = 1; // should never be used
+/** Max time (ms) to wait for the next fMP4 box before considering the stream stalled. */
+const SEGMENT_HEARTBEAT_TIMEOUT_MS = 10_000;
 
 const HKSVQuitReason = [
   'Normal',
@@ -45,6 +47,7 @@ export class RecordingDelegate implements CameraRecordingDelegate {
   private session?: {
     socket: net.Socket;
     process?: ChildProcessWithoutNullStreams;
+    ffmpeg?: FFmpeg;
     generator: AsyncGenerator<{
       header: Buffer;
       length: number;
@@ -208,38 +211,55 @@ export class RecordingDelegate implements CameraRecordingDelegate {
     let isInit = true;
     let fragmentCount = 0;
 
-    for await (const { header, type, data } of generator) {
-      if (!this.handlingStreamingRequest) {
-        log.debug(cameraName, 'Recording was ended prematurely.');
-        break;
-      }
+    let heartbeatTimer: NodeJS.Timeout | undefined;
+    const resetHeartbeat = () => {
+      if (heartbeatTimer) clearTimeout(heartbeatTimer);
+      heartbeatTimer = setTimeout(() => {
+        log.error(cameraName,
+          `No HKSV data received for ${SEGMENT_HEARTBEAT_TIMEOUT_MS / 1000}s — stream appears stalled. Ending recording.`);
+        this.handlingStreamingRequest = false;
+        this.session?.socket?.destroy();
+      }, SEGMENT_HEARTBEAT_TIMEOUT_MS);
+    };
+    resetHeartbeat();
 
-      if (isInit) {
-        initPending.push(header, data);
-        if (type === 'moov') {
-          const fragment = Buffer.concat(initPending);
-          initPending = [];
-          isInit = false;
-          log.debug(cameraName, `HKSV: Sending initialization segment, size: ${fragment.length}`);
-          yield { data: fragment, isLast: false };
-        }
-        continue;
-      }
-
-      if (type === 'moof') {
-        moofBuffer = Buffer.concat([header, data]);
-      } else if (type === 'mdat' && moofBuffer) {
-        const fragment = Buffer.concat([moofBuffer, header, data]);
-        moofBuffer = null;
-        fragmentCount++;
-        log.debug(cameraName, `HKSV: Fragment #${fragmentCount}, size: ${fragment.length}`);
-        yield { data: fragment, isLast: false };
-
-        if (!this.isMotionDetected()) {
-          log.debug(cameraName, 'Ending recording session due to motion stopped.');
+    try {
+      for await (const { header, type, data } of generator) {
+        if (!this.handlingStreamingRequest) {
+          log.debug(cameraName, 'Recording was ended prematurely.');
           break;
         }
+        resetHeartbeat();
+
+        if (isInit) {
+          initPending.push(header, data);
+          if (type === 'moov') {
+            const fragment = Buffer.concat(initPending);
+            initPending = [];
+            isInit = false;
+            log.debug(cameraName, `HKSV: Sending initialization segment, size: ${fragment.length}`);
+            yield { data: fragment, isLast: false };
+          }
+          continue;
+        }
+
+        if (type === 'moof') {
+          moofBuffer = Buffer.concat([header, data]);
+        } else if (type === 'mdat' && moofBuffer) {
+          const fragment = Buffer.concat([moofBuffer, header, data]);
+          moofBuffer = null;
+          fragmentCount++;
+          log.debug(cameraName, `HKSV: Fragment #${fragmentCount}, size: ${fragment.length}`);
+          yield { data: fragment, isLast: false };
+
+          if (!this.isMotionDetected()) {
+            log.debug(cameraName, 'Ending recording session due to motion stopped.');
+            break;
+          }
+        }
       }
+    } finally {
+      if (heartbeatTimer) clearTimeout(heartbeatTimer);
     }
   }
 
@@ -254,10 +274,21 @@ export class RecordingDelegate implements CameraRecordingDelegate {
   closeRecordingStream(streamId: number, reason: HDSProtocolSpecificErrorReason | undefined): void {
     log.info(this.camera.getName(), 'Closing recording process');
 
+    this.closeReason = reason;
+    this.handlingStreamingRequest = false;
+
     if (this.session) {
       log.debug(this.camera.getName(), 'Stopping recording session.');
-      this.session.socket?.destroy();
-      this.session.process?.kill('SIGKILL');
+      const isCancelled = reason === HDSProtocolSpecificErrorReason.CANCELLED;
+
+      if (isCancelled) {
+        this.session.socket?.destroy();
+        this.session.ffmpeg?.stop();
+      } else {
+        this.session.ffmpeg?.stop();
+        const socket = this.session.socket;
+        setTimeout(() => socket?.destroy(), 2_500);
+      }
       this.session = undefined;
     } else {
       log.warn('Recording session could not be closed gracefully.');
@@ -265,9 +296,6 @@ export class RecordingDelegate implements CameraRecordingDelegate {
 
     this.clearForceStopTimeout();
     this.resetMotionSensor();
-
-    this.closeReason = reason;
-    this.handlingStreamingRequest = false;
   }
 
   acknowledgeStream(streamId) {

--- a/src/utils/ffmpeg.ts
+++ b/src/utils/ffmpeg.ts
@@ -33,6 +33,8 @@ const TCP_SERVER_TIMEOUT_MS = 30_000;
 const PROCESS_RESULT_TIMEOUT_MS = 15_000;
 /** Grace period after SIGTERM before sending SIGKILL (ms) */
 const KILL_GRACE_PERIOD_MS = 2_000;
+/** Maximum allowed fMP4 box size (50 MB). Anything larger is likely corruption. */
+const MAX_FRAG_BOX_SIZE = 50 * 1024 * 1024;
 
 /** Returns true when the value is a non-empty string (guards `undefined | ''`). */
 function isNonEmpty(value: string | undefined): value is string {
@@ -623,6 +625,7 @@ export class FFmpegParameters {
             if (this.pixFormat) params.push(`-pix_fmt ${this.pixFormat}`);
             if (this.colorRange) params.push(`-color_range ${this.colorRange}`);
             if (this.codecOptions) params.push(this.codecOptions);
+            if (this.codec !== 'copy') params.push('-sc_threshold 0');
 
             params.push(...this.buildVideoFilterParams());
 
@@ -695,6 +698,7 @@ export class FFmpegParameters {
         params.push(...parameters[0].buildEncodingParameters());
         if (parameters[0].iFrameInterval) {
             params.push(`-force_key_frames expr:gte(t,n_forced*${parameters[0].iFrameInterval / 1000})`);
+            params.push('-sc_threshold 0');
         }
 
         // audio encoding
@@ -866,6 +870,7 @@ export class FFmpeg extends EventEmitter {
     public async startFragmentedMP4Session(): Promise<{
         socket: net.Socket;
         process?: ChildProcessWithoutNullStreams;
+        ffmpeg: FFmpeg;
         generator: AsyncGenerator<{
             header: Buffer;
             length: number;
@@ -882,6 +887,7 @@ export class FFmpeg extends EventEmitter {
                 resolve({
                     socket: socket,
                     process: this.process,
+                    ffmpeg: this,
                     generator: this.parseFragmentedMP4(socket),
                 });
             });
@@ -899,6 +905,13 @@ export class FFmpeg extends EventEmitter {
             const header = await this.readLength(socket, 8);
             const length = header.readInt32BE(0) - 8;
             const type = header.slice(4).toString();
+
+            if (length > MAX_FRAG_BOX_SIZE) {
+                throw new Error(
+                    `fMP4 box '${type}' reports size ${length} bytes, exceeding limit of ${MAX_FRAG_BOX_SIZE}. Stream likely corrupted.`,
+                );
+            }
+
             const data = await this.readLength(socket, length);
 
             yield {


### PR DESCRIPTION
## Problem

HKSV recordings have four reliability gaps that cause corrupted fragments, hung sessions, or zombie FFmpeg processes:

1. **Misaligned keyframes** — FFmpeg's scene-change detection inserts extra keyframes beyond `-force_key_frames`, breaking fMP4 fragment boundaries. Both homebridge-camera-ffmpeg and homebridge-unifi-protect use `-sc_threshold 0` to prevent this.

2. **OOM on corrupted streams** — `parseFragmentedMP4()` trusts the box size from the stream header. A corrupt stream reporting a multi-GB box will allocate until the process crashes. homebridge-camera-ffmpeg caps this at 50 MB.

3. **SIGKILL on recording close** — `closeRecordingStream()` immediately kills FFmpeg with SIGKILL, losing the last fragment and risking zombie processes. The streaming side already has graceful shutdown (SIGTERM + grace period) — recordings should too.

4. **Silent stream stalls** — If the P2P stream stops sending data but the TCP connection stays open, the recording blocks forever in `readLength()` with no logs. homebridge-unifi-protect uses a segment heartbeat to detect this.

## Changes

- Add `-sc_threshold 0` alongside `-force_key_frames` (recording) and for all non-copy video encoding
- Reject fMP4 boxes larger than 50 MB in the parser
- Replace `SIGKILL` with `FFmpeg.stop()` (SIGTERM + grace period) for recording shutdown
- Add 10s heartbeat timer in `generateFragments()` that ends the recording if no data arrives

## Test plan

- [x] Trigger HKSV recording — verify `-sc_threshold 0` appears in FFmpeg command (logs)
- [x] Close a recording normally — verify SIGTERM in logs instead of SIGKILL
- [x] Cancel a recording — verify immediate teardown still works
- [x] Check no regressions on RTSP-based and P2P-based cameras
