### PR TITLE
feat: P2P retry with exponential backoff and stdin backpressure

### DIFF
--- a/src/controller/LocalLivestreamManager.ts
+++ b/src/controller/LocalLivestreamManager.ts
@@ -16,10 +16,14 @@ export type LivestreamData = Pick<ActiveStream, 'videostream' | 'audiostream'>;
 
 const P2P_TIMEOUT_MS = 15_000;
 const DUPLICATE_STREAM_GUARD_S = 5;
+const MAX_RETRIES = 3;
+const BASE_RETRY_DELAY_MS = 2_000;
+const MAX_RETRY_DELAY_MS = 10_000;
 
 export class LocalLivestreamManager {
   private stationStream: ActiveStream | null = null;
   private pending: { deferred: Deferred<LivestreamData>; timer: NodeJS.Timeout } | null = null;
+  private retryCount = 0;
 
   private readonly eufyClient: EufySecurity;
   private readonly log: Logger<ILogObj>;
@@ -77,9 +81,21 @@ export class LocalLivestreamManager {
     this.log.debug(`Starting station livestream for serial: ${this.serialNumber}...`);
 
     const deferred = new Deferred<LivestreamData>();
+    this.issueP2PRequest(deferred);
+    return deferred.promise;
+  }
+
+  /**
+   * Issue a P2P start request with a timeout. Used for both initial
+   * attempts and retries (reusing the same deferred).
+   */
+  private issueP2PRequest(deferred: Deferred<LivestreamData>): void {
     const timer = setTimeout(() => {
-      this.log.error(`Livestream timeout: no P2P stream event received within ${P2P_TIMEOUT_MS / 1000}s for serial ${this.serialNumber}. Check eufy-lib.log for details.`);
-      this.settlePending('reject', 'Livestream timeout — check eufy-lib.log for P2P errors.');
+      this.log.error(
+        `Livestream timeout: no P2P stream event within ${P2P_TIMEOUT_MS / 1000}s` +
+        ` for serial ${this.serialNumber}.`,
+      );
+      this.settlePending('reject', new Error('Livestream timeout — check eufy-lib.log for P2P errors.'));
     }, P2P_TIMEOUT_MS);
 
     this.pending = { deferred, timer };
@@ -88,13 +104,12 @@ export class LocalLivestreamManager {
       this.log.error(`startStationLivestream failed: ${err}`);
       this.settlePending('reject', err);
     });
-
-    return deferred.promise;
   }
 
   /**
    * Settle (resolve or reject) the pending start promise, clear the timer,
-   * and optionally stop the livestream on rejection.
+   * and optionally stop the livestream on rejection. On failure, retries
+   * with exponential backoff before final rejection.
    */
   private settlePending(action: 'resolve', value: LivestreamData): void;
   private settlePending(action: 'reject', reason: unknown): void;
@@ -102,11 +117,37 @@ export class LocalLivestreamManager {
     const p = this.pending;
     if (!p) return;
     clearTimeout(p.timer);
-    this.pending = null;
 
     if (action === 'resolve') {
+      this.retryCount = 0;
+      this.pending = null;
       p.deferred.resolve(payload as LivestreamData);
+      return;
+    }
+
+    // Failure path — retry with exponential backoff if attempts remain
+    if (this.retryCount < MAX_RETRIES) {
+      const delay = Math.min(
+        BASE_RETRY_DELAY_MS * Math.pow(2, this.retryCount) + Math.random() * 1000,
+        MAX_RETRY_DELAY_MS,
+      );
+      this.retryCount++;
+      this.log.warn(
+        `P2P connection failed. Retrying in ${(delay / 1000).toFixed(1)}s` +
+        ` (attempt ${this.retryCount + 1}/${MAX_RETRIES + 1})...`,
+      );
+      // Keep pending alive during backoff so new callers piggyback
+      p.timer = setTimeout(() => {
+        this.log.debug(
+          `Retrying station livestream for serial: ${this.serialNumber}` +
+          ` (attempt ${this.retryCount + 1}/${MAX_RETRIES + 1})...`,
+        );
+        this.issueP2PRequest(p.deferred);
+      }, delay);
     } else {
+      this.retryCount = 0;
+      this.pending = null;
+      this.log.error(`Livestream failed after ${MAX_RETRIES + 1} attempts.`);
       p.deferred.reject(payload instanceof Error ? payload : new Error(String(payload)));
       this.stopLocalLiveStream();
     }
@@ -114,6 +155,11 @@ export class LocalLivestreamManager {
 
   public stopLocalLiveStream(): void {
     this.log.debug('Stopping station livestream.');
+    this.retryCount = 0;
+    if (this.pending) {
+      clearTimeout(this.pending.timer);
+      this.pending = null;
+    }
     this.eufyClient.stopStationLivestream(this.serialNumber).catch((err) => {
       this.log.warn(`stopStationLivestream failed: ${err}`);
     });

--- a/src/utils/ffmpeg.ts
+++ b/src/utils/ffmpeg.ts
@@ -311,7 +311,21 @@ export class FFmpegParameters {
 
     public async setInputStream(input: Readable) {
         const { port } = await createOneShotTcpServer((socket) => {
-            input.pipe(socket);
+            // Manual backpressure handling instead of pipe() — prevents
+            // unbounded memory growth when FFmpeg is slower than the camera
+            // (common on Raspberry Pi during HKSV transcoding).
+            socket.on('drain', () => input.resume());
+
+            input.on('data', (chunk: Buffer) => {
+                if (!socket.write(chunk)) {
+                    input.pause();
+                }
+            });
+
+            input.on('end', () => socket.end());
+            input.on('error', () => socket.destroy());
+            socket.on('error', () => { if (!input.destroyed) input.destroy(); });
+            socket.on('close', () => { if (!input.destroyed) input.destroy(); });
         });
         this.setInputSource(`tcp://127.0.0.1:${port}`);
     }


### PR DESCRIPTION
## Summary

P2P connections to Eufy stations are inherently flaky (Wi-Fi interference, station busy, NAT traversal). Currently a single failure after a 15s timeout kills the stream with no recovery. This adds:

- **Retry with exponential backoff** — up to 3 retries (2s → 4s → 8s + jitter, capped at 10s) before giving up. Concurrent callers piggyback on the same pending request during retries. Inspired by unifi-protect's retry strategy.
- **Backpressure on FFmpeg stdin** — replaces `input.pipe(socket)` with manual write/drain/pause/resume. Prevents unbounded memory growth when FFmpeg transcodes slower than the camera sends (common on Raspberry Pi during HKSV recording).

## Files changed

- `LocalLivestreamManager.ts` — retry logic in `settlePending()`, extracted `issueP2PRequest()` for reuse across attempts
- `ffmpeg.ts` — `setInputStream()` backpressure handling

## Test plan

- [x] Kill station Wi-Fi during P2P stream → verify retry with backoff in logs
- [x] Verify concurrent stream requests still piggyback correctly during retry backoff
- [x] Run HKSV recording on Raspberry Pi → monitor RSS for memory growth over time
- [x] Call `stopLocalLiveStream()` during retry backoff → verify clean cancellation
