### PR TITLE
fix: guard isRtspReady against undefined RTSP URL

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -226,7 +226,7 @@ export function isRtspReady(device: Camera, cameraConfig: CameraConfig): boolean
     [!device.hasProperty('rtspStream'), 'device not compatible with RTSP'],
     [!cameraConfig.rtsp, 'RTSP not enabled in camera config'],
     [!device.getPropertyValue(PropertyName.DeviceRTSPStream), 'RTSP capability not enabled on device'],
-    [device.getPropertyValue(PropertyName.DeviceRTSPStreamUrl) === '', 'RTSP URL is unknown'],
+    [!device.getPropertyValue(PropertyName.DeviceRTSPStreamUrl), 'RTSP URL is unknown'],
   ];
 
   for (const [failed, reason] of checks) {


### PR DESCRIPTION
## Summary

- Harden `isRtspReady()` to treat `undefined` RTSP URL as not ready — the previous check only matched empty string (`=== ''`), so when the underlying library failed to store the URL property, `undefined` passed through and FFmpeg was launched with `-i undefined`

Depends on upstream fix: bropat/eufy-security-client (SoloCam E42 missing `rtspStreamUrl` property metadata)

Closes #838
