### PR TITLE
fix: set ADTS input format for P2P audio streams

### DIFF
--- a/src/controller/LocalLivestreamManager.ts
+++ b/src/controller/LocalLivestreamManager.ts
@@ -8,11 +8,12 @@ import { ILogObj, Logger } from 'tslog';
 interface ActiveStream {
   videostream: Readable;
   audiostream: Readable;
+  metadata: StreamMetadata;
   createdAt: number;
 }
 
 /** Data returned to consumers — only the streams they need. */
-export type LivestreamData = Pick<ActiveStream, 'videostream' | 'audiostream'>;
+export type LivestreamData = Pick<ActiveStream, 'videostream' | 'audiostream' | 'metadata'>;
 
 const P2P_TIMEOUT_MS = 15_000;
 const DUPLICATE_STREAM_GUARD_S = 5;
@@ -201,7 +202,7 @@ export class LocalLivestreamManager {
     this.log.debug(`${station.getName()} P2P livestream for ${device.getName()} started.`);
     this.log.debug('Stream metadata:', JSON.stringify(metadata));
 
-    this.stationStream = { videostream, audiostream, createdAt: Date.now() };
+    this.stationStream = { videostream, audiostream, metadata, createdAt: Date.now() };
     this.settlePending('resolve', this.stationStream);
   };
 }

--- a/src/controller/recordingDelegate.ts
+++ b/src/controller/recordingDelegate.ts
@@ -13,7 +13,7 @@ import { EufySecurityPlatform } from '../platform.js';
 import { CameraConfig, VideoConfig } from '../utils/configTypes.js';
 import { FFmpeg, FFmpegParameters } from '../utils/ffmpeg.js';
 import net from 'net';
-import { CHAR, SERV, isRtspReady, log, ffmpegLoggerFactory } from '../utils/utils.js';
+import { CHAR, SERV, isRtspReady, applyP2PAudioFormat, log, ffmpegLoggerFactory } from '../utils/utils.js';
 import { LocalLivestreamManager } from './LocalLivestreamManager.js';
 import { snapshotDelegate } from './snapshotDelegate.js';
 
@@ -112,6 +112,7 @@ export class RecordingDelegate implements CameraRecordingDelegate {
     } else {
       const streamData = await this.localLivestreamManager.getLocalLiveStream();
       await videoParams.setInputStream(streamData.videostream);
+      applyP2PAudioFormat(audioParams, streamData.metadata.audioCodec);
       await audioParams.setInputStream(streamData.audiostream);
     }
   }

--- a/src/controller/streamingDelegate.ts
+++ b/src/controller/streamingDelegate.ts
@@ -21,7 +21,7 @@ import { CameraAccessory } from '../accessories/CameraAccessory.js';
 import { SessionInfo, VideoConfig } from '../utils/configTypes.js';
 import { FFmpeg, FFmpegParameters } from '../utils/ffmpeg.js';
 import { TalkbackStream } from '../utils/Talkback.js';
-import { HAP, isRtspReady, ffmpegLoggerFactory } from '../utils/utils.js';
+import { HAP, isRtspReady, applyP2PAudioFormat, ffmpegLoggerFactory } from '../utils/utils.js';
 import { LocalLivestreamManager } from './LocalLivestreamManager.js';
 import { snapshotDelegate } from './snapshotDelegate.js';
 
@@ -294,7 +294,10 @@ export class StreamingDelegate implements CameraStreamingDelegate {
     const streamData = await this.localLivestreamManager.getLocalLiveStream();
     this.log.debug('Livestream obtained successfully. Setting up FFmpeg input streams...');
     await videoParams.setInputStream(streamData.videostream);
-    await audioParams?.setInputStream(streamData.audiostream);
+    if (audioParams) {
+      applyP2PAudioFormat(audioParams, streamData.metadata.audioCodec);
+      await audioParams.setInputStream(streamData.audiostream);
+    }
     this.log.debug('FFmpeg input streams configured.');
     return true;
   }

--- a/src/utils/ffmpeg.ts
+++ b/src/utils/ffmpeg.ts
@@ -396,6 +396,10 @@ export class FFmpegParameters {
         this.inputSource = `-i ${value}`;
     }
 
+    public setInputFormat(value: string) {
+        this.inputFormat = value;
+    }
+
     public async setInputStream(input: Readable) {
         const { port } = await createOneShotTcpServer((socket) => {
             // Manual backpressure handling instead of pipe() — prevents

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -6,7 +6,8 @@ import { HAP as HAPHB } from 'homebridge';
 import type { Characteristic, Service } from 'homebridge';
 
 import { CameraConfig } from './configTypes.js';
-import { Camera, PropertyName } from 'eufy-security-client';
+import { AudioCodec, Camera, PropertyName } from 'eufy-security-client';
+import { FFmpegParameters } from './ffmpeg.js';
 
 export let HAP!: HAPHB;
 export let SERV!: typeof Service;
@@ -237,4 +238,21 @@ export function isRtspReady(device: Camera, cameraConfig: CameraConfig): boolean
   }
 
   return true;
+}
+
+/**
+ * Configure FFmpeg input format hints for a P2P audio stream based on the
+ * audio codec reported by the eufy-security-client stream metadata.
+ */
+export function applyP2PAudioFormat(params: FFmpegParameters, codec: AudioCodec): void {
+  switch (codec) {
+    case AudioCodec.AAC:
+    case AudioCodec.AAC_LC:
+    case AudioCodec.AAC_ELD:
+      params.setInputFormat('adts');
+      break;
+    case AudioCodec.NONE:
+    case AudioCodec.UNKNOWN:
+      break;
+  }
 }


### PR DESCRIPTION
## Summary

- Pass `-f adts` input format hint to FFmpeg for P2P audio streams so it can parse raw AAC frames — without it FFmpeg reads data but fails with "Invalid data found when processing input" (confirmed on SoloCam E42 with AAC-ELD audio)
- Expose stream metadata from `LocalLivestreamManager` so delegates can inspect the audio codec before configuring FFmpeg

Closes #838
