### PR TITLE
fix: use aac demuxer instead of adts muxer for P2P audio input

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -249,7 +249,7 @@ export function applyP2PAudioFormat(params: FFmpegParameters, codec: AudioCodec)
     case AudioCodec.AAC:
     case AudioCodec.AAC_LC:
     case AudioCodec.AAC_ELD:
-      params.setInputFormat('adts');
+      params.setInputFormat('aac');
       break;
     case AudioCodec.NONE:
     case AudioCodec.UNKNOWN:


### PR DESCRIPTION
## Summary

- Fix P2P audio input format: `adts` is an FFmpeg output-only muxer, not a valid input demuxer — causes `Unknown input format: 'adts'` on every P2P audio stream since beta.6
- Use `aac` (the correct FFmpeg demuxer for raw ADTS AAC) instead

Closes #838

## Test plan

- [x] Verify P2P livestream audio works on cameras with audioCodec 1 (AAC) and audioCodec 3 (AAC_ELD)
- [x] Verify HKSV recording captures audio
