### PR TITLE
fix: use libfdk_aac decoder for AAC-ELD P2P audio

### DIFF
--- a/src/utils/ffmpeg.ts
+++ b/src/utils/ffmpeg.ts
@@ -400,6 +400,10 @@ export class FFmpegParameters {
         this.inputFormat = value;
     }
 
+    public setInputCodec(value: string) {
+        this.inputCodec = value;
+    }
+
     public async setInputStream(input: Readable) {
         const { port } = await createOneShotTcpServer((socket) => {
             // Manual backpressure handling instead of pipe() — prevents

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -248,8 +248,11 @@ export function applyP2PAudioFormat(params: FFmpegParameters, codec: AudioCodec)
   switch (codec) {
     case AudioCodec.AAC:
     case AudioCodec.AAC_LC:
+      params.setInputFormat('aac');
+      break;
     case AudioCodec.AAC_ELD:
       params.setInputFormat('aac');
+      params.setInputCodec('libfdk_aac');
       break;
     case AudioCodec.NONE:
     case AudioCodec.UNKNOWN:


### PR DESCRIPTION
## Summary

- FFmpeg's native AAC decoder cannot handle AAC-ELD frames from P2P streams (E42 and similar cameras report audioCodec 3)
- Use `libfdk_aac` as the input decoder for AAC_ELD — it fully supports ELD decoding
- AAC and AAC_LC continue using the native decoder (works fine)

Relates to #838

## Test plan

- [x] Verify P2P audio works on cameras with audioCodec 3 (AAC_ELD), e.g. Solo Cam E42
- [x] Verify P2P audio still works on cameras with audioCodec 1 (AAC), e.g. Doorbell E340
