### PR TITLE
fix: reuse P2P session between snapshot and livestream

### DIFF
--- a/src/controller/LocalLivestreamManager.ts
+++ b/src/controller/LocalLivestreamManager.ts
@@ -30,26 +30,17 @@ export class LocalLivestreamManager {
   private stopGraceTimer: NodeJS.Timeout | null = null;
   /** Number of consumers currently holding a forked copy of the stream. */
   private activeConsumers = 0;
-  /** Per-consumer max-duration timer — resets each time a new consumer joins. */
-  private maxDurationTimer: NodeJS.Timeout | null = null;
 
   private readonly eufyClient: EufySecurity;
   private readonly log: Logger<ILogObj>;
   private readonly serialNumber: string;
-  /** Maximum livestream duration in seconds (0 = unlimited). */
-  private readonly maxLivestreamSeconds: number;
 
   constructor(camera: CameraAccessory) {
     this.eufyClient = camera.platform.eufyClient;
     this.serialNumber = camera.device.getSerial();
     this.log = camera.log;
-    this.maxLivestreamSeconds = camera.platform.config.CameraMaxLivestreamDuration;
 
     this.log.debug(`LocalLivestreamManager initialized for ${camera.device.getName()} (serial: ${this.serialNumber})`);
-
-    // Disable eufy-security-client's built-in timer — we manage it ourselves
-    // so we can reset it when a new consumer joins.
-    this.eufyClient.setCameraMaxLivestreamDuration(0);
 
     this.eufyClient.on('station livestream start', this.onStationLivestreamStart);
     this.eufyClient.on('station livestream stop', this.onStationLivestreamStop);
@@ -57,10 +48,6 @@ export class LocalLivestreamManager {
 
   /** Destroy active streams and reset state. */
   private destroyStreams(): void {
-    if (this.maxDurationTimer) {
-      clearTimeout(this.maxDurationTimer);
-      this.maxDurationTimer = null;
-    }
     if (this.stationStream) {
       this.stationStream.audiostream.unpipe();
       this.stationStream.audiostream.destroy();
@@ -69,28 +56,6 @@ export class LocalLivestreamManager {
       this.stationStream = null;
       this.activeConsumers = 0;
     }
-  }
-
-  /**
-   * (Re)start the max-duration timer.  Called each time a new consumer joins
-   * so that every consumer gets the full configured duration from the moment
-   * it starts watching.
-   */
-  private resetMaxDurationTimer(): void {
-    if (this.maxLivestreamSeconds <= 0) return;
-
-    if (this.maxDurationTimer) {
-      clearTimeout(this.maxDurationTimer);
-    }
-    this.log.debug(`Max-duration timer (re)set to ${this.maxLivestreamSeconds}s.`);
-    this.maxDurationTimer = setTimeout(() => {
-      this.maxDurationTimer = null;
-      this.log.info(
-        `Stopping livestream for ${this.serialNumber} — reached max duration ` +
-        `(${this.maxLivestreamSeconds}s).`,
-      );
-      this.forceStopLocalLiveStream();
-    }, this.maxLivestreamSeconds * 1000);
   }
 
   /**
@@ -117,7 +82,6 @@ export class LocalLivestreamManager {
 
     const runtime = ((Date.now() - this.stationStream.createdAt) / 1000).toFixed(1);
     this.activeConsumers++;
-    this.resetMaxDurationTimer();
     this.log.debug(
       `Providing forked stream (consumers: ${this.activeConsumers}, ` +
       `stream age: ${runtime}s).`,


### PR DESCRIPTION
## Summary

When `snapshotHandlingMethod` is `AlwaysFresh`, opening the Apple Home app triggers a P2P snapshot grab followed immediately by a livestream request. The rapid stop/start cycle causes some stations (e.g. SoloCam E42) to terminate the new stream after only 5-15s instead of the configured max duration.

This fix makes `LocalLivestreamManager` reuse the same P2P session across snapshot and livestream by:

- Returning PassThrough forks instead of raw P2P streams, so a consumer's FFmpeg exit doesn't destroy the underlying session
- Tracking active consumers with reference counting — the P2P session only stops when the last consumer releases
- Adding a 5s grace period after the last consumer releases, bridging the snapshot-to-livestream gap

**Note:** The max-duration timer remains in eufy-security-client. When the snapshot triggers the P2P stream, the timer starts from that point — the livestream loses ~2-3s of the configured duration. A future PR to eufy-security-client will add a timer reset API to eliminate this gap.

## Test plan

- [x] Camera with `snapshotHandlingMethod: 1` (AlwaysFresh): open Home app, tap camera — livestream should run for the full configured duration instead of 5-15s
- [x] Multiple HomeKit clients (iPhone + Apple TV): both viewing same camera simultaneously — neither should cut the other's stream short
- [x] Camera with `snapshotHandlingMethod: 3` (CloudOnly): verify no regression — livestream should work as before
- [x] Verify stream stops after configured `CameraMaxLivestreamDuration`