### PR TITLE
fix: E340 HKSV recording aspect ratio + talkback fixes

### DIFF
--- a/src/controller/recordingDelegate.ts
+++ b/src/controller/recordingDelegate.ts
@@ -140,6 +140,15 @@ export class RecordingDelegate implements CameraRecordingDelegate {
       videoParams.setupForRecording(videoConfig, this.configuration);
       audioParams.setupForRecording(videoConfig, this.configuration);
 
+      // E340 Dual Camera Doorbell stitches two camera feeds into a single
+      // portrait stream (1600×2200 native).  The default crop filter would
+      // discard most of the frame to fit landscape 1920×1080.  Instead, pad
+      // the portrait image into the landscape container with black sidebars.
+      if (this.camera.isBatteryDoorbellDualE340()) {
+        log.debug(this.camera.getName(), 'E340 portrait feed detected — using pad filter for HKSV recording.');
+        videoParams.setPortraitPadFilter();
+      }
+
       await this.configureInputSource(videoParams, audioParams);
 
       // Opportunistically capture a snapshot from the HKSV recording stream

--- a/src/utils/Talkback.ts
+++ b/src/utils/Talkback.ts
@@ -4,6 +4,35 @@ import { EufySecurityPlatform } from '../platform.js';
 import { Device, EufySecurity, Station } from 'eufy-security-client';
 import { log } from './utils.js';
 
+/**
+ * Split a buffer into individual ADTS frames.
+ * FFmpeg writes arbitrary-sized chunks that may contain multiple ADTS frames
+ * or partial frames spanning chunk boundaries. The doorbell expects each P2P
+ * audio packet to contain exactly one ADTS frame.
+ */
+function splitAdtsFrames(data: Buffer): { frames: Buffer[]; remainder: Buffer } {
+  const frames: Buffer[] = [];
+  let offset = 0;
+  while (offset + 7 <= data.length) {
+    // Check for ADTS syncword (0xFFF in first 12 bits)
+    if (data[offset] !== 0xFF || (data[offset + 1] & 0xF0) !== 0xF0) {
+      offset++;
+      continue;
+    }
+    // Frame length is in bits 30-42 (13 bits) spanning bytes 3-5
+    const frameLength = ((data[offset + 3] & 0x03) << 11) |
+                        (data[offset + 4] << 3) |
+                        ((data[offset + 5] & 0xE0) >> 5);
+    if (frameLength < 7 || offset + frameLength > data.length) {
+      break; // incomplete frame — save remainder for next chunk
+    }
+    frames.push(Buffer.from(data.subarray(offset, offset + frameLength)));
+    offset += frameLength;
+  }
+  const remainder = offset < data.length ? Buffer.from(data.subarray(offset)) : Buffer.alloc(0);
+  return { frames, remainder };
+}
+
 export class TalkbackStream extends Duplex {
 
   private eufyClient: EufySecurity;
@@ -16,6 +45,13 @@ export class TalkbackStream extends Duplex {
 
   private targetStream?: Writable;
 
+  // Bound handler references so they can be properly removed
+  private _boundOnTalkbackStarted: (station: Station, device: Device, stream: Writable) => void;
+  private _boundOnTalkbackStopped: (station: Station, device: Device) => void;
+
+  // ADTS frame accumulation buffer for partial frames across chunks
+  private _adtsBuffer: Buffer = Buffer.alloc(0);
+
   constructor(platform: EufySecurityPlatform, camera: Device) {
     super();
 
@@ -23,8 +59,14 @@ export class TalkbackStream extends Duplex {
     this.cameraName = camera.getName();
     this.cameraSN = camera.getSerial();
 
-    this.eufyClient.on('station talkback start', this.onTalkbackStarted);
-    this.eufyClient.on('station talkback stop', this.onTalkbackStopped);
+    // Bind handlers to preserve 'this' context when called as event callbacks
+    this._boundOnTalkbackStarted = this.onTalkbackStarted.bind(this);
+    this._boundOnTalkbackStopped = this.onTalkbackStopped.bind(this);
+
+    log.debug(this.cameraName, 'TalkbackStream created for device ' + this.cameraSN);
+
+    this.eufyClient.on('station talkback start', this._boundOnTalkbackStarted);
+    this.eufyClient.on('station talkback stop', this._boundOnTalkbackStopped);
   }
 
   private onTalkbackStarted(station: Station, device: Device, stream: Writable) {
@@ -40,6 +82,12 @@ export class TalkbackStream extends Duplex {
 
     this.targetStream = stream;
     this.pipe(this.targetStream);
+
+    // Flush any cached audio data now that targetStream is connected
+    while (this.cacheData.length > 0) {
+      const data = this.cacheData.shift();
+      this.push(data);
+    }
   }
 
   private onTalkbackStopped(station: Station, device: Device) {
@@ -56,9 +104,10 @@ export class TalkbackStream extends Duplex {
   }
 
   public stopTalkbackStream(): void {
-    // remove event listeners
-    this.eufyClient.removeListener('station talkback start', this.onTalkbackStarted);
-    this.eufyClient.removeListener('station talkback stop', this.onTalkbackStopped);
+    log.debug(this.cameraName, 'stopTalkbackStream called');
+    // Remove event listeners using the bound references
+    this.eufyClient.removeListener('station talkback start', this._boundOnTalkbackStarted);
+    this.eufyClient.removeListener('station talkback stop', this._boundOnTalkbackStopped);
 
     this.stopTalkback();
     this.unpipe();
@@ -83,12 +132,24 @@ export class TalkbackStream extends Duplex {
       this.stopTalkback();
     }, 2000);
 
-    if (this.targetStream) {
-      this.push(chunk);
-    } else {
-      this.cacheData.push(chunk);
-      this.startTalkback();
+    // Accumulate with any leftover partial frame from last chunk
+    const buf = this._adtsBuffer.length > 0
+      ? Buffer.concat([this._adtsBuffer, chunk])
+      : chunk;
+
+    const { frames, remainder } = splitAdtsFrames(buf);
+    this._adtsBuffer = remainder;
+
+    // Push each individual ADTS frame as a separate P2P audio packet
+    for (const frame of frames) {
+      if (this.targetStream) {
+        this.push(frame);
+      } else {
+        this.cacheData.push(frame);
+        this.startTalkback();
+      }
     }
+
     callback();
   }
 

--- a/src/utils/ffmpeg.ts
+++ b/src/utils/ffmpeg.ts
@@ -717,6 +717,24 @@ export class FFmpegParameters {
     }
 
     /**
+     * Overrides the default scale/crop behaviour so a portrait (tall) source
+     * is fitted inside the target resolution with black sidebars instead of
+     * being cropped.  The `none` sentinel prevents `buildVideoFilterParams`
+     * from appending any additional default scaling.
+     */
+    public setPortraitPadFilter(): void {
+        if (!this.width || !this.height) {
+            return;
+        }
+        this.crop = false;
+        this.filters = [
+            `scale=-2:${this.height}:force_original_aspect_ratio=decrease`,
+            `pad=${this.width}:${this.height}:(ow-iw)/2:(oh-ih)/2:black`,
+            'none',
+        ].join(',');
+    }
+
+    /**
      * Builds scale/crop video filter arguments based on current width, height, crop settings,
      * and any user-specified filters. Shared between video and snapshot encoding.
      */


### PR DESCRIPTION
## Summary

The Eufy E340 Dual Camera Doorbell (T8214) stitches two separate camera feeds into a single **portrait** stream (1600×2200 native resolution). The current HKSV recording pipeline applies a landscape crop filter (`scale + crop` to 1920×1080), which discards approximately 60% of the E340's vertical frame — resulting in recordings that capture only a narrow horizontal slice of what the doorbell actually sees.

This PR fixes two areas:

### 1. HKSV Recording Aspect Ratio (`recordingDelegate.ts`, `ffmpeg.ts`)

- Adds `FFmpegParameters.setPortraitPadFilter()` — a public method that replaces the default crop filter with a **scale + pad** pipeline, fitting the full portrait image inside the 1920×1080 HKSV container with black sidebars.
- In `RecordingDelegate.handleRecordingStreamRequest()`, detects the E340 via `camera.isBatteryDoorbellDualE340()` and applies the pad filter automatically.
- Standard landscape cameras are completely unaffected — the pad filter is only applied for E340 devices.

**Note:** Because the full portrait feed is fitted into a landscape container, the actual video content appears smaller with black bars on each side. Users can **pinch-to-zoom** on HKSV recordings in the Home app to view the footage at full size — this has been tested and is fully functional.

### 2. Talkback Stream Reliability (`Talkback.ts`)

Three bugs that cause talkback (two-way audio) to silently fail on battery doorbells:

- **`this` binding loss:** Event handlers (`onTalkbackStarted`/`onTalkbackStopped`) were registered as unbound method references. When fired as callbacks, `this` was `undefined`, causing silent failures. Fixed by storing `.bind(this)` references and using them for both registration and removal.
- **ADTS frame splitting:** FFmpeg writes arbitrary-sized audio chunks that may contain multiple ADTS frames or partial frames spanning chunk boundaries. The doorbell's P2P protocol expects exactly one ADTS frame per audio packet. Added `splitAdtsFrames()` to properly parse ADTS syncwords/lengths, split complete frames, and buffer partial frames across chunks.
- **Cache flush on connect:** When talkback starts, cached audio data was never flushed to the newly connected target stream. Added a flush loop in `onTalkbackStarted` so buffered frames are sent immediately once the P2P talkback channel is established.

## Test Plan

- [x] HKSV recordings on E340 now capture the full dual-camera portrait view (both top and bottom camera feeds visible)
- [x] Pinch-to-zoom on HKSV recordings in Home app works correctly for full-size viewing
- [x] Standard landscape cameras remain unaffected (no filter override applied)
- [x] Talkback audio reaches the E340 doorbell speaker
- [x] Event handler cleanup works correctly (no leaked listeners)

## Related Issues

- #838 (HKSV recording aspect ratio)
- #741 (E340 dual camera support)