### PR TITLE
fix: HKSV recording stability — cleanup ordering, heartbeat, logging

### DIFF
--- a/src/controller/recordingDelegate.ts
+++ b/src/controller/recordingDelegate.ts
@@ -19,7 +19,7 @@ import { snapshotDelegate } from './snapshotDelegate.js';
 
 const MAX_RECORDING_MINUTES = 1; // should never be used
 /** Max time (ms) to wait for the next fMP4 box before considering the stream stalled. */
-const SEGMENT_HEARTBEAT_TIMEOUT_MS = 10_000;
+const SEGMENT_HEARTBEAT_TIMEOUT_MS = 30_000;
 
 const HKSVQuitReason = [
   'Normal',
@@ -266,31 +266,22 @@ export class RecordingDelegate implements CameraRecordingDelegate {
   }
 
   updateRecordingActive(active: boolean): void {
-    log.debug(`Recording: ${active}`, this.accessory.displayName);
+    log.info(this.camera.getName(), `HKSV updateRecordingActive: ${active}`);
   }
 
   updateRecordingConfiguration(configuration: CameraRecordingConfiguration | undefined): void {
+    log.info(this.camera.getName(), `HKSV updateRecordingConfiguration called: ${configuration ? 'config received' : 'undefined'}`);
     this.configuration = configuration;
   }
 
   closeRecordingStream(streamId: number, reason: HDSProtocolSpecificErrorReason | undefined): void {
-    log.info(this.camera.getName(), 'Closing recording process');
-
-    this.closeReason = reason;
-    this.handlingStreamingRequest = false;
+    log.info(this.camera.getName(),
+      `Closing recording process (reason: ${reason !== undefined ? HKSVQuitReason[reason] ?? reason : 'none'})`);
 
     if (this.session) {
       log.debug(this.camera.getName(), 'Stopping recording session.');
-      const isCancelled = reason === HDSProtocolSpecificErrorReason.CANCELLED;
-
-      if (isCancelled) {
-        this.session.socket?.destroy();
-        this.session.ffmpeg?.stop();
-      } else {
-        this.session.ffmpeg?.stop();
-        const socket = this.session.socket;
-        setTimeout(() => socket?.destroy(), 2_500);
-      }
+      this.session.socket?.destroy();
+      this.session.process?.kill('SIGKILL');
       this.session = undefined;
     } else {
       log.warn('Recording session could not be closed gracefully.');
@@ -298,6 +289,9 @@ export class RecordingDelegate implements CameraRecordingDelegate {
 
     this.clearForceStopTimeout();
     this.resetMotionSensor();
+
+    this.closeReason = reason;
+    this.handlingStreamingRequest = false;
   }
 
   acknowledgeStream(streamId) {


### PR DESCRIPTION
## Summary

HKSV recordings on the E340 Dual Cam Doorbell (T8214) fail to store in HomeKit. Three bugs in `recordingDelegate.ts` cause recordings to terminate prematurely or leave orphaned processes that block subsequent recordings.

Tested on real E340 hardware — HKSV recordings now complete and store correctly after these fixes.

## Bugs Fixed

### 1. `closeRecordingStream` sets flags before cleanup (root cause)

`handlingStreamingRequest = false` and `closeReason` are set **before** the session socket/process are cleaned up. This allows the `generateFragments` async generator to observe `handlingStreamingRequest === false` and break out of the loop while ffmpeg is still flushing fMP4 data to the socket — resulting in incomplete or zero-length recordings that HomeKit discards.

**Fix:** Move flag assignment to **after** `socket.destroy()` / `process.kill()` and session teardown.

### 2. `closeRecordingStream` uses delayed socket destruction

Non-cancelled closures call `ffmpeg.stop()` then delay `socket.destroy()` by 2.5 seconds via `setTimeout`. This leaves file handles open and can result in orphaned ffmpeg processes that hold locks, preventing the next recording from starting.

**Fix:** Use immediate `socket.destroy()` + `process.kill('SIGKILL')` for deterministic cleanup in all cases.

### 3. Heartbeat timeout too aggressive (10s)

The 10-second `SEGMENT_HEARTBEAT_TIMEOUT_MS` causes recordings to abort on brief P2P network hiccups or slow connections with the error "stream appears stalled." The heartbeat mechanism itself is valuable for detecting genuinely dead streams, but 10s is too short.

**Fix:** Increase to 30 seconds.

### 4. HKSV event logging lost

`updateRecordingActive` uses `log.debug` with swapped arguments (`active` first, `displayName` second), and `updateRecordingConfiguration` has no logging at all. This makes it impossible to tell from logs whether HomeKit is actually triggering recordings.

**Fix:** Restore `log.info` with camera name and descriptive messages for both callbacks.

## Changes

Single file: `src/controller/recordingDelegate.ts`

```diff
- const SEGMENT_HEARTBEAT_TIMEOUT_MS = 10_000;
+ const SEGMENT_HEARTBEAT_TIMEOUT_MS = 30_000;
```

```diff
  updateRecordingActive(active: boolean): void {
-   log.debug(`Recording: ${active}`, this.accessory.displayName);
+   log.info(this.camera.getName(), `HKSV updateRecordingActive: ${active}`);
  }

  updateRecordingConfiguration(configuration: ...): void {
+   log.info(this.camera.getName(), `HKSV updateRecordingConfiguration called: ${configuration ? 'config received' : 'undefined'}`);
    this.configuration = configuration;
  }
```

```diff
  closeRecordingStream(streamId, reason): void {
-   this.closeReason = reason;
-   this.handlingStreamingRequest = false;
    if (this.session) {
-     // conditional ffmpeg.stop() + delayed socket.destroy()
+     this.session.socket?.destroy();
+     this.session.process?.kill('SIGKILL');
      this.session = undefined;
    }
    this.clearForceStopTimeout();
    this.resetMotionSensor();
+   this.closeReason = reason;
+   this.handlingStreamingRequest = false;
  }
```

## Test Plan

- [x] HKSV recordings complete and appear in HomeKit on E340 (T8214)
- [x] No orphaned ffmpeg processes after recording ends
- [x] `updateRecordingActive` and `updateRecordingConfiguration` visible in logs at info level
- [x] Stalled stream detection still works (at 30s threshold)
- [x] No regressions — all changes scoped to recording delegate lifecycle

## Related

- #822 — E340 talkback/HKSV investigation with pcap analysis