### PR TITLE
chore: use .tar.gz extension for diagnostics uploads

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -153,7 +153,7 @@ Typical flow: **planner** -> **developer** -> **qa**. Use **architect** for expl
 
 For issue triage, use the `support` skill with an issue number (e.g. `/support 423`). For the full triage reference, see `.github/prompts/diag-triage.prompt.md`. For adding new device types, use the `new-device-support` skill. Key points:
 
-- Diagnostics archives are encrypted (RSA-4096 + AES-256-GCM); decrypt with `node scripts/decrypt-diagnostics.mjs <file>.tar.gz.enc`
+- Diagnostics archives are encrypted (RSA-4096 + AES-256-GCM); decrypt with `node scripts/decrypt-diagnostics.mjs <file>.tar.gz`
 - Always check archive completeness before analysis -- missing runtime logs means the plugin wasn't running
 - When diagnostics are incomplete or debug is disabled, ask the user to upgrade to the latest [beta](https://github.com/homebridge-plugins/homebridge-eufy-security/wiki/Special-Version-(BETA---RC---HKSV)) and follow the [Basic Troubleshooting](https://github.com/homebridge-plugins/homebridge-eufy-security/wiki/Basic-Troubleshooting) steps to enable Detailed Logging, reproduce the issue, and re-export diagnostics
 - Narrow down whether the issue is in `homebridge-eufy-security` (accessory registration, HomeKit mapping, config handling) or in `eufy-security-client` (device discovery, property events, P2P, push notifications)

--- a/.github/prompts/diag-triage.prompt.md
+++ b/.github/prompts/diag-triage.prompt.md
@@ -8,10 +8,10 @@ This prompt is used to triage issues reported by users of the homebridge-eufy-se
 
 ## Diagnostics Archive Structure
 
-Diagnostics archives are **encrypted** (RSA-4096 + AES-256-GCM) and include a creation timestamp in the header. The downloaded file has a `.tar.gz.enc` extension. Before analysis, decrypt it:
+Diagnostics archives are **encrypted** (RSA-4096 + AES-256-GCM) and include a creation timestamp in the header. The downloaded file has a `.tar.gz` extension (the content is encrypted despite the extension — this allows direct upload to GitHub). Before analysis, decrypt it:
 
 ```bash
-node scripts/decrypt-diagnostics.mjs <file>.tar.gz.enc
+node scripts/decrypt-diagnostics.mjs <file>.tar.gz
 ```
 
 The script prints the archive creation date and warns if the archive is older than 90 days.

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -1213,8 +1213,7 @@ class UiServer extends HomebridgePluginUiServer {
       const encryptedBuffer = encryptDiagnostics(fileBuffer);
 
       this.pushEvent('diagnosticsProgress', { progress: 90, status: 'Returning encrypted archive' });
-      const encFilename = archiveName + '.enc';
-      return { buffer: encryptedBuffer, filename: encFilename };
+      return { buffer: encryptedBuffer, filename: archiveName };
     } catch (error) {
       this.log.error('Error while generating diagnostics archive: ' + error);
       throw error;

--- a/scripts/decrypt-diagnostics.mjs
+++ b/scripts/decrypt-diagnostics.mjs
@@ -1,18 +1,18 @@
 #!/usr/bin/env node
 
 /**
- * Decrypt and extract an encrypted diagnostics archive (.enc) produced by the plugin.
+ * Decrypt and extract an encrypted diagnostics archive produced by the plugin.
  *
  * Usage:
- *   node decrypt-diagnostics.mjs <encrypted-file.enc> [private-key.pem]
+ *   node decrypt-diagnostics.mjs <encrypted-file.tar.gz> [private-key.pem]
  *
  * If the private key is omitted, the script looks for it in the keys/
  * directory next to itself (keys/diagnostics_private.pem).
  *
- * The archive is decrypted and extracted into a folder next to the .enc file,
+ * The archive is decrypted and extracted into a folder next to the input file,
  * named after the archive (e.g. diagnostics-2026-03-02-11-25-31/).
  *
- * File format of the .enc file:
+ * File format (the .tar.gz is actually encrypted, not a plain gzip):
  *   [4 bytes]  – magic: "DIAG"
  *   [1 byte]   – format version (currently 0x01)
  *   [8 bytes]  – creation timestamp (BigUInt64BE, ms since Unix epoch)
@@ -51,7 +51,7 @@ function main() {
   const args = process.argv.slice(2);
 
   if (args.length < 1) {
-    console.error('Usage: node decrypt-diagnostics.mjs <encrypted-file.enc> [private-key.pem]');
+    console.error('Usage: node decrypt-diagnostics.mjs <encrypted-file.tar.gz> [private-key.pem]');
     process.exit(1);
   }
 
@@ -176,8 +176,7 @@ function main() {
   // Determine output directory next to the .enc file
   const encDir = path.dirname(encFile);
   const baseName = path.basename(encFile)
-    .replace(/\.tar\.gz\.enc$/, '')
-    .replace(/\.enc$/, '');
+    .replace(/\.tar\.gz(?:\.enc)?$/, '');
   const outDir = path.join(encDir, baseName);
 
   // --- Safety: inspect tar contents before extracting (piped via stdin, no temp file) ---


### PR DESCRIPTION
## Summary
- Diagnostics archives now use `.tar.gz` extension instead of `.tar.gz.enc`, so users can upload them directly to GitHub issues without workarounds (GitHub rejects `.enc` files)
- The decrypt script accepts both old `.tar.gz.enc` and new `.tar.gz` filenames