### PR TITLE
fix: use libfdk_aac decoder for P2P AAC audio (multi-RDB ADTS)

### DIFF
--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -7,7 +7,7 @@ import type { Characteristic, Service } from 'homebridge';
 
 import { CameraConfig } from './configTypes.js';
 import { AudioCodec, Camera, PropertyName } from 'eufy-security-client';
-import { FFmpegParameters } from './ffmpeg.js';
+import { FFmpegParameters, hasFdkAac } from './ffmpeg.js';
 
 export let HAP!: HAPHB;
 export let SERV!: typeof Service;
@@ -249,6 +249,11 @@ export function applyP2PAudioFormat(params: FFmpegParameters, codec: AudioCodec)
     case AudioCodec.AAC:
     case AudioCodec.AAC_LC:
       params.setInputFormat('aac');
+      // Some cameras (e.g. SoloCam E42) send multi-RDB ADTS frames that the
+      // native FFmpeg AAC decoder cannot parse.  libfdk_aac handles them fine.
+      if (hasFdkAac()) {
+        params.setInputCodec('libfdk_aac');
+      }
       break;
     case AudioCodec.AAC_ELD:
       params.setInputFormat('aac');


### PR DESCRIPTION
## Summary

- Some cameras (e.g. SoloCam E42) send P2P audio as ADTS frames containing multiple Raw Data Blocks (RDBs). FFmpeg's native AAC decoder doesn't support this and crashes with `"More than one AAC RDB per ADTS frame is not implemented"`.
- `libfdk_aac` handles multi-RDB ADTS frames correctly and is already used as the input decoder for AAC-ELD streams — this extends it to plain AAC and AAC-LC when available.
- Fixes audio on cameras that send non-standard AAC packaging (observed on SoloCam E42 T8173).

## Test plan

- [x] Verify `libfdk_aac` is detected on target platform (`ffmpeg -encoders | grep libfdk_aac`)
- [x] Livestream a SoloCam E42 — confirm audio works (previously: "No audio data received" / FFmpeg crash)
- [x] Livestream other cameras (e.g. E340, indoor cams) — confirm no regression
- [x] HKSV recording with audio on affected camera

Closes #838
