### PR TITLE
fix: treat FFmpeg exit after stop() as expected instead of error

### DIFF
--- a/src/controller/recordingDelegate.ts
+++ b/src/controller/recordingDelegate.ts
@@ -158,7 +158,7 @@ export class RecordingDelegate implements CameraRecordingDelegate {
       );
 
       ffmpeg.on('error', (error) => {
-        log.error(this.camera.getName(), 'HKSV recording FFmpeg error: ' + error);
+        log.debug(this.camera.getName(), 'HKSV recording FFmpeg error: ' + error);
       });
 
       this.session = await ffmpeg.startFragmentedMP4Session();

--- a/src/controller/snapshotDelegate.ts
+++ b/src/controller/snapshotDelegate.ts
@@ -409,7 +409,7 @@ export class snapshotDelegate {
     await configure(params);
     const ffmpeg = new FFmpeg(label, params, ffmpegLoggerFactory.forSnapshots());
     ffmpeg.on('error', (error) => {
-      this.log.error('Snapshot FFmpeg error: ' + error);
+      this.log.debug('Snapshot FFmpeg error: ' + error);
     });
     return ffmpeg.getResult(input);
   }

--- a/src/utils/ffmpeg.ts
+++ b/src/utils/ffmpeg.ts
@@ -1263,13 +1263,16 @@ export class FFmpeg extends EventEmitter {
     private onProcessExit(code: number, signal: NodeJS.Signals) {
         this.emit('exit');
 
+        const wasStopRequested = !!this.killTimeout;
         if (this.killTimeout) {
             clearTimeout(this.killTimeout);
         }
 
         const message = 'FFmpeg exited with code: ' + code + ' and signal: ' + signal;
-        if (this.killTimeout && code === 0) {
-            this.log.info(this.name, message + ' (Expected)');
+        if (wasStopRequested) {
+            // stop() was called — any exit code is expected (non-zero typically
+            // means broken pipe from socket teardown during HKSV recording close).
+            this.log.debug(this.name, message + ' (Expected)');
         } else if (code === null || code === 255) {
             if (this.process?.killed) {
                 this.log.info(this.name, message + ' (Forced)');


### PR DESCRIPTION
## Summary

Follow-up to #881. When `stop()` is called on an FFmpeg process, any exit code is expected — non-zero codes like 224 or 152 are the normal result of socket teardown during HKSV recording close (FFmpeg reports "Broken pipe" when the TCP output socket is destroyed).

Previously, only exit code 0 was treated as "expected" after `stop()`, so codes like 224 emitted an unhandled `error` event that crashed the child bridge (#881 added error listeners to prevent the crash). This PR fixes the root cause: `onProcessExit` now treats all exit codes as expected when `stop()` was called, logging at DEBUG instead of emitting an error event.

## Changes

- `ffmpeg.ts`: Capture `killTimeout` state before clearing it, then treat any exit code as expected when stop was requested
- `recordingDelegate.ts`: Downgrade FFmpeg error listener from ERROR to DEBUG (safety net)
- `snapshotDelegate.ts`: Same — downgrade error listener to DEBUG

## Test plan

- [ ] Trigger HKSV recording → verify no ERROR-level FFmpeg exit messages in logs
- [ ] Verify "Expected" appears at DEBUG level after recording close
- [ ] Force-kill a livestream mid-stream → verify unexpected exits still log as errors
