### PR TITLE
feat: debug recording download with raw P2P capture

### DIFF
--- a/homebridge-ui/public/app.js
+++ b/homebridge-ui/public/app.js
@@ -153,6 +153,11 @@ const App = {
         DiagnosticsView.render(this._root);
         break;
 
+      case 'recordings':
+        homebridge.enableSaveButton();
+        RecordingsView.render(this._root);
+        break;
+
       default:
         // Unknown route — try dashboard if we have stations, otherwise login
         if (this.state.stations.length > 0) {

--- a/homebridge-ui/public/index.html
+++ b/homebridge-ui/public/index.html
@@ -24,4 +24,5 @@
 <script src="views/unsupported-detail.js"></script>
 <script src="views/settings.js"></script>
 <script src="views/diagnostics.js"></script>
+<script src="views/recordings.js"></script>
 <script src="app.js"></script>

--- a/homebridge-ui/public/services/api.js
+++ b/homebridge-ui/public/services/api.js
@@ -211,4 +211,40 @@ const Api = {
   async getSystemInfo() {
     return homebridge.request('/systemInfo');
   },
+
+  /**
+   * List all available debug recordings.
+   * @returns {Promise<{recordings: Array}>}
+   */
+  async listDebugRecordings() {
+    return homebridge.request('/debugRecordings');
+  },
+
+  /**
+   * Download a chunk of a debug recording file.
+   * @param {string} filename
+   * @param {number} offset
+   * @param {number} chunkSize
+   * @returns {Promise<{data: Buffer, totalSize: number, offset: number, chunkSize: number, done: boolean, filename: string}>}
+   */
+  async downloadDebugRecording(filename, offset = 0, chunkSize = 256 * 1024) {
+    return homebridge.request('/downloadDebugRecording', { filename, offset, chunkSize });
+  },
+
+  /**
+   * Delete a specific debug recording file.
+   * @param {string} filename
+   * @returns {Promise<{deleted: boolean, filename: string}>}
+   */
+  async deleteDebugRecording(filename) {
+    return homebridge.request('/deleteDebugRecording', { filename });
+  },
+
+  /**
+   * Delete all debug recording files.
+   * @returns {Promise<{deleted: number}>}
+   */
+  async deleteAllDebugRecordings() {
+    return homebridge.request('/deleteAllDebugRecordings');
+  },
 };

--- a/homebridge-ui/public/views/diagnostics.js
+++ b/homebridge-ui/public/views/diagnostics.js
@@ -106,6 +106,18 @@ const DiagnosticsView = {
     livestreamHint.innerHTML = Helpers.iconHtml('warning.svg') + ' <strong>Debug Livestream:</strong> Only enable this if asked by a developer. Diagnostics files may contain recorded video sessions. Use <strong>Clean Storage</strong> to remove them afterwards, or reposition the camera if you are not comfortable sharing recordings.';
     livestreamSection.appendChild(livestreamHint);
 
+    // View Recordings button — always visible when debug livestream section is shown
+    const recBtnWrapper = document.createElement('div');
+    recBtnWrapper.className = 'mt-2';
+    const btnRecordings = document.createElement('button');
+    btnRecordings.className = 'btn btn-outline-info btn-sm';
+    btnRecordings.innerHTML = '';
+    btnRecordings.appendChild(Helpers.icon('inventory.svg'));
+    btnRecordings.append(' View Recordings');
+    btnRecordings.addEventListener('click', () => App.navigate('recordings'));
+    recBtnWrapper.appendChild(btnRecordings);
+    livestreamSection.appendChild(recBtnWrapper);
+
     step1.appendChild(livestreamSection);
     stepsSection.appendChild(step1);
 

--- a/homebridge-ui/public/views/recordings.js
+++ b/homebridge-ui/public/views/recordings.js
@@ -1,0 +1,300 @@
+/**
+ * Recordings View — list, download, and manage debug livestream recordings.
+ * Users can compare raw (pre-FFmpeg) vs processed (post-FFmpeg) MP4 files
+ * to narrow down whether streaming issues originate in the underlying
+ * library or in the plugin's FFmpeg pipeline.
+ */
+// eslint-disable-next-line no-unused-vars
+const RecordingsView = {
+
+  _downloadInProgress: false,
+
+  async render(container) {
+    container.innerHTML = '';
+
+    // Header
+    const header = document.createElement('div');
+    header.className = 'eufy-header';
+
+    const backBtn = document.createElement('button');
+    backBtn.className = 'btn btn-link p-0';
+    backBtn.innerHTML = '&larr; Back';
+    backBtn.style.textDecoration = 'none';
+    backBtn.addEventListener('click', () => App.navigate('diagnostics'));
+
+    const titleEl = document.createElement('h4');
+    titleEl.textContent = 'Debug Recordings';
+
+    header.appendChild(backBtn);
+    header.appendChild(titleEl);
+    header.appendChild(document.createElement('div'));
+    container.appendChild(header);
+
+    // Info banner
+    const info = document.createElement('div');
+    info.className = 'alert alert-info';
+    info.style.fontSize = '0.85rem';
+    info.innerHTML = Helpers.iconHtml('info.svg') + ' <strong>Raw</strong> recordings capture the P2P feed directly from the camera (before FFmpeg). <strong>Processed</strong> recordings capture the re-encoded stream sent to HomeKit. Compare them to narrow down where an issue originates.';
+    container.appendChild(info);
+
+    // Loading spinner
+    const spinner = document.createElement('div');
+    spinner.id = 'recordings-spinner';
+    spinner.className = 'd-flex justify-content-center my-3';
+    spinner.innerHTML = '<div class="spinner-border spinner-border-sm text-primary" role="status"><span class="visually-hidden">Loading...</span></div>';
+    container.appendChild(spinner);
+
+    // Recordings list container
+    const listContainer = document.createElement('div');
+    listContainer.id = 'recordings-list';
+    container.appendChild(listContainer);
+
+    // Actions row
+    const actionsRow = document.createElement('div');
+    actionsRow.className = 'mt-3';
+    actionsRow.id = 'recordings-actions';
+    actionsRow.style.display = 'none';
+
+    const btnDeleteAll = document.createElement('button');
+    btnDeleteAll.className = 'btn btn-outline-danger btn-sm';
+    btnDeleteAll.innerHTML = '';
+    btnDeleteAll.appendChild(Helpers.icon('delete.svg'));
+    btnDeleteAll.append(' Delete All Recordings');
+    btnDeleteAll.addEventListener('click', () => this._confirmDeleteAll(container));
+
+    actionsRow.appendChild(btnDeleteAll);
+    container.appendChild(actionsRow);
+
+    // Download progress area
+    const progressArea = document.createElement('div');
+    progressArea.id = 'recording-download-progress';
+    container.appendChild(progressArea);
+
+    // Load recordings
+    await this._loadRecordings(container);
+  },
+
+  async _loadRecordings(container) {
+    const spinner = container.querySelector('#recordings-spinner');
+    const listContainer = container.querySelector('#recordings-list');
+    const actionsRow = container.querySelector('#recordings-actions');
+
+    try {
+      const result = await Api.listDebugRecordings();
+      const recordings = result.recordings || [];
+
+      if (spinner) spinner.style.display = 'none';
+
+      if (recordings.length === 0) {
+        listContainer.innerHTML = `
+          <div class="text-muted text-center py-4" style="font-size: 0.9rem;">
+            No debug recordings found.<br>
+            <small>Enable <strong>Debug Livestream</strong> in Diagnostics, restart the plugin, then open a camera in the Home app.</small>
+          </div>
+        `;
+        return;
+      }
+
+      if (actionsRow) actionsRow.style.display = '';
+
+      // Group by serial
+      const grouped = {};
+      for (const rec of recordings) {
+        if (!grouped[rec.serial]) grouped[rec.serial] = [];
+        grouped[rec.serial].push(rec);
+      }
+
+      listContainer.innerHTML = '';
+
+      for (const [serial, recs] of Object.entries(grouped)) {
+        const section = document.createElement('div');
+        section.className = 'settings-section';
+
+        const sectionTitle = document.createElement('div');
+        sectionTitle.className = 'detail-section__title';
+        sectionTitle.textContent = serial;
+        section.appendChild(sectionTitle);
+
+        const table = document.createElement('table');
+        table.className = 'table table-sm';
+        table.style.fontSize = '0.85rem';
+
+        const thead = document.createElement('thead');
+        thead.innerHTML = '<tr><th>Type</th><th>Date</th><th>Size</th><th></th></tr>';
+        table.appendChild(thead);
+
+        const tbody = document.createElement('tbody');
+
+        for (const rec of recs) {
+          const tr = document.createElement('tr');
+
+          // Type badge
+          const tdType = document.createElement('td');
+          const badge = document.createElement('span');
+          badge.className = rec.type === 'raw'
+            ? 'badge bg-success'
+            : 'badge bg-primary';
+          badge.textContent = rec.type === 'raw' ? 'Raw' : 'Processed';
+          tdType.appendChild(badge);
+          tr.appendChild(tdType);
+
+          // Date
+          const tdDate = document.createElement('td');
+          tdDate.textContent = rec.createdAtISO
+            ? new Date(rec.createdAtISO).toLocaleString()
+            : rec.timestamp || 'Unknown';
+          tr.appendChild(tdDate);
+
+          // Size
+          const tdSize = document.createElement('td');
+          tdSize.textContent = rec.sizeMB + ' MB';
+          tr.appendChild(tdSize);
+
+          // Actions
+          const tdActions = document.createElement('td');
+          tdActions.className = 'text-end';
+
+          const btnDownload = document.createElement('button');
+          btnDownload.className = 'btn btn-outline-primary btn-sm me-1';
+          btnDownload.title = 'Download';
+          btnDownload.appendChild(Helpers.icon('download.svg'));
+          btnDownload.addEventListener('click', () => this._downloadRecording(container, rec.filename, rec.sizeBytes));
+          tdActions.appendChild(btnDownload);
+
+          const btnDelete = document.createElement('button');
+          btnDelete.className = 'btn btn-outline-danger btn-sm';
+          btnDelete.title = 'Delete';
+          btnDelete.appendChild(Helpers.icon('delete.svg'));
+          btnDelete.addEventListener('click', async () => {
+            try {
+              await Api.deleteDebugRecording(rec.filename);
+              homebridge.toast.success('Deleted ' + rec.filename);
+              await this._loadRecordings(container);
+            } catch (e) {
+              homebridge.toast.error('Delete failed: ' + (e.message || e));
+            }
+          });
+          tdActions.appendChild(btnDelete);
+
+          tr.appendChild(tdActions);
+          tbody.appendChild(tr);
+        }
+
+        table.appendChild(tbody);
+        section.appendChild(table);
+        listContainer.appendChild(section);
+      }
+    } catch (e) {
+      if (spinner) spinner.style.display = 'none';
+      listContainer.innerHTML = '<div class="alert alert-danger">Failed to load recordings: ' + Helpers.escHtml(e.message || String(e)) + '</div>';
+    }
+  },
+
+  /**
+   * Download a recording file in chunks and trigger browser download.
+   * Uses paginated reads to avoid loading the entire file into memory at once.
+   */
+  async _downloadRecording(container, filename, totalSize) {
+    if (this._downloadInProgress) {
+      homebridge.toast.warning('A download is already in progress.');
+      return;
+    }
+    this._downloadInProgress = true;
+
+    const progressArea = container.querySelector('#recording-download-progress');
+    if (progressArea) {
+      progressArea.innerHTML = `
+        <div class="mt-2">
+          <div class="progress">
+            <div class="progress-bar progress-bar-striped progress-bar-animated" role="progressbar" style="width: 0%" id="rec-progress-bar"></div>
+          </div>
+          <small class="text-muted" id="rec-progress-status">Downloading...</small>
+        </div>
+      `;
+    }
+
+    try {
+      const chunks = [];
+      let offset = 0;
+      const chunkSize = 256 * 1024; // 256 KB per request
+
+      while (true) {
+        const result = await Api.downloadDebugRecording(filename, offset, chunkSize);
+
+        if (result.data) {
+          const bytes = new Uint8Array(result.data.data || result.data);
+          chunks.push(bytes);
+        }
+
+        // Update progress
+        const pct = totalSize > 0 ? Math.min(100, Math.round((result.offset / totalSize) * 100)) : 0;
+        const bar = document.querySelector('#rec-progress-bar');
+        const status = document.querySelector('#rec-progress-status');
+        if (bar) bar.style.width = pct + '%';
+        if (status) status.textContent = `Downloading... ${pct}%`;
+
+        if (result.done) break;
+        offset = result.offset;
+      }
+
+      // Combine chunks and trigger browser download
+      const totalLength = chunks.reduce((sum, c) => sum + c.length, 0);
+      const combined = new Uint8Array(totalLength);
+      let pos = 0;
+      for (const chunk of chunks) {
+        combined.set(chunk, pos);
+        pos += chunk.length;
+      }
+
+      const blob = new Blob([combined], { type: 'video/mp4' });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = filename;
+      document.body.appendChild(a);
+      a.click();
+      document.body.removeChild(a);
+      URL.revokeObjectURL(url);
+
+      homebridge.toast.success('Downloaded: ' + filename);
+    } catch (e) {
+      homebridge.toast.error('Download failed: ' + (e.message || e));
+    } finally {
+      this._downloadInProgress = false;
+      if (progressArea) progressArea.innerHTML = '';
+    }
+  },
+
+  _confirmDeleteAll(container) {
+    const existing = container.querySelector('#delete-all-confirm');
+    if (existing) { existing.remove(); return; }
+
+    const confirm = document.createElement('div');
+    confirm.id = 'delete-all-confirm';
+    confirm.className = 'alert alert-danger mt-2';
+    confirm.innerHTML = `
+      <strong>Delete all recordings?</strong> This cannot be undone.
+      <div class="mt-2">
+        <button class="btn btn-danger btn-sm me-2" id="btn-confirm-delete-all">Yes, Delete All</button>
+        <button class="btn btn-outline-secondary btn-sm" id="btn-cancel-delete-all">Cancel</button>
+      </div>
+    `;
+
+    confirm.querySelector('#btn-confirm-delete-all').addEventListener('click', async () => {
+      try {
+        const result = await Api.deleteAllDebugRecordings();
+        homebridge.toast.success('Deleted ' + result.deleted + ' recording(s).');
+        confirm.remove();
+        await this._loadRecordings(container);
+      } catch (e) {
+        homebridge.toast.error('Delete failed: ' + (e.message || e));
+      }
+    });
+
+    confirm.querySelector('#btn-cancel-delete-all').addEventListener('click', () => {
+      confirm.remove();
+    });
+
+    container.appendChild(confirm);
+  },
+};

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -212,6 +212,10 @@ class UiServer extends HomebridgePluginUiServer {
     this.onRequest('/skipIntelWait', this.skipIntelWait.bind(this));
     this.onRequest('/discoveryState', this.getDiscoveryState.bind(this));
     this.onRequest('/unsupportedDevices', this.loadUnsupportedDevices.bind(this));
+    this.onRequest('/debugRecordings', this.listDebugRecordings.bind(this));
+    this.onRequest('/downloadDebugRecording', this.downloadDebugRecording.bind(this));
+    this.onRequest('/deleteDebugRecording', this.deleteDebugRecording.bind(this));
+    this.onRequest('/deleteAllDebugRecordings', this.deleteAllDebugRecordings.bind(this));
   }
 
   skipIntelWait() {
@@ -1302,6 +1306,152 @@ class UiServer extends HomebridgePluginUiServer {
       os: `${os.type()} ${os.release()} (${os.arch()})`,
       devices: deviceSummary,
     };
+  }
+
+  /**
+   * List all debug recording files available for download.
+   */
+  async listDebugRecordings() {
+    const recordingsDir = path.join(this.storagePath, 'recordings');
+    try {
+      if (!fs.existsSync(recordingsDir)) {
+        return { recordings: [] };
+      }
+      const files = fs.readdirSync(recordingsDir)
+        .filter(f => f.endsWith('.mp4'))
+        .map(filename => {
+          const filePath = path.join(recordingsDir, filename);
+          try {
+            const stats = fs.statSync(filePath);
+            // Parse filename: <serial>_<timestamp>_<type>.mp4
+            const match = filename.match(/^([A-Za-z0-9_-]+?)_(\d{4}-\d{2}-\d{2}T[\d-]+Z?)(?:_(raw|processed))?\.mp4$/);
+            return {
+              filename,
+              serial: match ? match[1] : 'unknown',
+              type: match && match[3] ? match[3] : 'processed',
+              sizeBytes: stats.size,
+              sizeMB: (stats.size / (1024 * 1024)).toFixed(1),
+              createdAt: stats.mtimeMs,
+              createdAtISO: new Date(stats.mtimeMs).toISOString(),
+            };
+          } catch {
+            return null;
+          }
+        })
+        .filter(f => f !== null)
+        .sort((a, b) => b.createdAt - a.createdAt);
+      return { recordings: files };
+    } catch (error) {
+      this.log.error('Error listing debug recordings: ' + error);
+      throw error;
+    }
+  }
+
+  /**
+   * Download a debug recording file in chunks to avoid memory spikes.
+   * Request: { filename: string, offset?: number, chunkSize?: number }
+   * Returns: { data: Buffer (base64), totalSize: number, offset: number, chunkSize: number, done: boolean }
+   */
+  async downloadDebugRecording(options = {}) {
+    const { filename, offset: rawOffset = 0, chunkSize: rawChunkSize = 256 * 1024 } = options;
+
+    if (!filename || typeof filename !== 'string') {
+      throw new Error('Missing or invalid filename parameter.');
+    }
+
+    // Coerce and clamp parameters
+    const numOffset = Number(rawOffset) || 0;
+    const MAX_CHUNK = 2 * 1024 * 1024; // 2 MB
+    const numChunkSize = Math.min(Number(rawChunkSize) || 256 * 1024, MAX_CHUNK);
+
+    const recordingsDir = path.join(this.storagePath, 'recordings');
+    const sanitized = path.basename(filename);
+    const filePath = path.join(recordingsDir, sanitized);
+    const resolved = path.resolve(filePath);
+
+    // Path traversal guard
+    if (!resolved.startsWith(path.resolve(recordingsDir))) {
+      throw new Error('Invalid filename.');
+    }
+
+    if (!fs.existsSync(resolved)) {
+      throw new Error('Recording file not found.');
+    }
+
+    const stats = fs.statSync(resolved);
+    const totalSize = stats.size;
+    const readSize = Math.min(numChunkSize, totalSize - numOffset);
+
+    if (numOffset >= totalSize || readSize <= 0) {
+      return { data: null, totalSize, offset: numOffset, chunkSize: 0, done: true };
+    }
+
+    const fd = fs.openSync(resolved, 'r');
+    const buf = Buffer.alloc(readSize);
+    fs.readSync(fd, buf, 0, readSize, numOffset);
+    fs.closeSync(fd);
+
+    const newOffset = numOffset + readSize;
+
+    return {
+      data: buf,
+      totalSize,
+      offset: newOffset,
+      chunkSize: readSize,
+      done: newOffset >= totalSize,
+      filename: sanitized,
+    };
+  }
+
+  /**
+   * Delete a specific debug recording file.
+   */
+  async deleteDebugRecording(options = {}) {
+    const { filename } = options;
+
+    if (!filename || typeof filename !== 'string') {
+      throw new Error('Missing or invalid filename parameter.');
+    }
+
+    const recordingsDir = path.join(this.storagePath, 'recordings');
+    const sanitized = path.basename(filename);
+    const filePath = path.join(recordingsDir, sanitized);
+    const resolved = path.resolve(filePath);
+
+    if (!resolved.startsWith(path.resolve(recordingsDir))) {
+      throw new Error('Invalid filename.');
+    }
+
+    if (!fs.existsSync(resolved)) {
+      throw new Error('Recording file not found.');
+    }
+
+    fs.unlinkSync(resolved);
+    this.log.info(`Deleted debug recording: ${sanitized}`);
+    return { deleted: true, filename: sanitized };
+  }
+
+  /**
+   * Delete all debug recording files.
+   */
+  async deleteAllDebugRecordings() {
+    const recordingsDir = path.join(this.storagePath, 'recordings');
+    if (!fs.existsSync(recordingsDir)) {
+      return { deleted: 0 };
+    }
+
+    const files = fs.readdirSync(recordingsDir).filter(f => f.endsWith('.mp4'));
+    let deleted = 0;
+    for (const file of files) {
+      try {
+        fs.unlinkSync(path.join(recordingsDir, file));
+        deleted++;
+      } catch {
+        // ignore individual failures
+      }
+    }
+    this.log.info(`Deleted ${deleted} debug recording(s)`);
+    return { deleted };
   }
 }
 

--- a/src/controller/DebugRecordingManager.ts
+++ b/src/controller/DebugRecordingManager.ts
@@ -1,0 +1,436 @@
+import { Readable } from 'stream';
+import { spawn, ChildProcessWithoutNullStreams } from 'child_process';
+import { mkdirSync, readdirSync, statSync, unlinkSync, createReadStream, openSync, readSync, closeSync } from 'fs';
+import * as path from 'path';
+import * as net from 'net';
+import { StreamMetadata, AudioCodec } from 'eufy-security-client';
+import { ILogObj, Logger } from 'tslog';
+import { pickPort } from 'pick-port';
+
+/** Default global cap for all debug recordings on disk (bytes). */
+const DEFAULT_MAX_TOTAL_BYTES = 500 * 1024 * 1024; // 500 MB
+
+/** Maximum number of recording files to retain per camera. */
+const DEFAULT_MAX_FILES_PER_CAMERA = 5;
+
+/** Maximum chunk size for paginated downloads (2 MB). */
+const MAX_DOWNLOAD_CHUNK_BYTES = 2 * 1024 * 1024;
+
+/** FFmpeg input format string for P2P audio codecs. */
+function audioFormatForCodec(codec: AudioCodec): string | null {
+  switch (codec) {
+    case AudioCodec.AAC:
+    case AudioCodec.AAC_LC:
+    case AudioCodec.AAC_ELD:
+      return 'aac';
+    default:
+      return null;
+  }
+}
+
+export interface DebugRecordingFile {
+  filename: string;
+  serial: string;
+  timestamp: string;
+  type: 'raw' | 'processed';
+  sizeBytes: number;
+  createdAt: number;
+}
+
+/** Per-camera recording session state. */
+interface RecordingSession {
+  ffmpegProcess: ChildProcessWithoutNullStreams;
+  videoSocket: net.Socket | null;
+  audioSocket: net.Socket | null;
+}
+
+/**
+ * Manages raw P2P stream capture to MP4 files for debugging.
+ *
+ * When enabled, creates a codec-copy FFmpeg process that muxes the raw
+ * H.264 video and AAC audio from the P2P layer directly into an MP4
+ * container — no re-encoding, minimal CPU overhead.
+ *
+ * Supports concurrent recordings from multiple cameras via a per-serial
+ * session map.
+ *
+ * Also provides disk management (rotation, global cap) and listing
+ * of available recordings for download.
+ */
+export class DebugRecordingManager {
+  private readonly sessions = new Map<string, RecordingSession>();
+  private readonly recordingsDir: string;
+  private readonly maxTotalBytes: number;
+  private readonly maxFilesPerCamera: number;
+
+  constructor(
+    private readonly log: Logger<ILogObj>,
+    eufyPath: string,
+    maxTotalBytes?: number,
+    maxFilesPerCamera?: number,
+  ) {
+    this.recordingsDir = path.join(eufyPath, 'recordings');
+    this.maxTotalBytes = maxTotalBytes ?? DEFAULT_MAX_TOTAL_BYTES;
+    this.maxFilesPerCamera = maxFilesPerCamera ?? DEFAULT_MAX_FILES_PER_CAMERA;
+    mkdirSync(this.recordingsDir, { recursive: true });
+  }
+
+  /** Start recording the raw P2P feed to an MP4 file for a specific camera. */
+  async startRawRecording(
+    serial: string,
+    videostream: Readable,
+    audiostream: Readable,
+    metadata: StreamMetadata,
+  ): Promise<string | null> {
+    const sanitizedSerial = serial.replace(/[^A-Za-z0-9_-]/g, '');
+
+    if (this.sessions.has(sanitizedSerial)) {
+      this.log.warn(`Raw debug recording already in progress for ${sanitizedSerial} — skipping.`);
+      return null;
+    }
+
+    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const filename = `${sanitizedSerial}_${ts}_raw.mp4`;
+    const outputPath = path.join(this.recordingsDir, filename);
+
+    const audioFormat = audioFormatForCodec(metadata.audioCodec);
+
+    try {
+      const videoPort = await this.createInputServer(sanitizedSerial, videostream, 'video');
+      const audioPort = audioFormat ? await this.createInputServer(sanitizedSerial, audiostream, 'audio') : null;
+
+      const args = this.buildRawMuxArgs(videoPort, audioPort, audioFormat, outputPath);
+
+      this.log.info(`Starting raw debug recording: ${filename}`);
+      this.log.debug(`FFmpeg raw mux args: ffmpeg ${args.join(' ')}`);
+
+      const ffmpeg = spawn('ffmpeg', args, { env: process.env });
+
+      const session: RecordingSession = {
+        ffmpegProcess: ffmpeg,
+        videoSocket: null,
+        audioSocket: null,
+      };
+      this.sessions.set(sanitizedSerial, session);
+
+      ffmpeg.stderr.on('data', (data: Buffer) => {
+        const line = data.toString().trim();
+        if (line) {
+          this.log.debug(`[Raw Recording ${sanitizedSerial}] ${line}`);
+        }
+      });
+
+      ffmpeg.on('error', (err) => {
+        this.log.error(`Raw recording FFmpeg error (${sanitizedSerial}): ${err.message}`);
+        this.cleanupSession(sanitizedSerial);
+      });
+
+      ffmpeg.on('exit', (code) => {
+        this.log.info(`Raw recording for ${sanitizedSerial} stopped (exit code: ${code ?? 'signal'}).`);
+        this.cleanupSession(sanitizedSerial);
+        this.enforceRetentionPolicy(sanitizedSerial);
+      });
+
+      return outputPath;
+    } catch (err) {
+      this.log.error(`Failed to start raw recording for ${sanitizedSerial}: ${err}`);
+      this.cleanupSession(sanitizedSerial);
+      return null;
+    }
+  }
+
+  /** Stop the raw recording for a specific camera. */
+  stopRawRecording(serial?: string): void {
+    const sanitizedSerial = serial?.replace(/[^A-Za-z0-9_-]/g, '');
+
+    if (sanitizedSerial) {
+      this.stopSessionBySerial(sanitizedSerial);
+    } else {
+      // Stop all active sessions
+      for (const key of [...this.sessions.keys()]) {
+        this.stopSessionBySerial(key);
+      }
+    }
+  }
+
+  /** List all available debug recording files. */
+  listRecordings(): DebugRecordingFile[] {
+    try {
+      const files = readdirSync(this.recordingsDir)
+        .filter(f => f.endsWith('.mp4'))
+        .map(filename => this.parseRecordingFilename(filename))
+        .filter((f): f is DebugRecordingFile => f !== null)
+        .sort((a, b) => b.createdAt - a.createdAt);
+      return files;
+    } catch {
+      return [];
+    }
+  }
+
+  /** Read a recording file in chunks for streaming download. */
+  getRecordingStream(filename: string): { stream: ReturnType<typeof createReadStream>; size: number } | null {
+    const resolved = this.resolveRecordingPath(filename);
+    if (!resolved) return null;
+
+    try {
+      const stats = statSync(resolved);
+      return { stream: createReadStream(resolved), size: stats.size };
+    } catch {
+      return null;
+    }
+  }
+
+  /** Read a chunk of a recording file for paginated download via IPC. */
+  readRecordingChunk(filename: string, offset: number, length: number): { data: Buffer; totalSize: number } | null {
+    const resolved = this.resolveRecordingPath(filename);
+    if (!resolved) return null;
+
+    try {
+      const stats = statSync(resolved);
+      if (offset >= stats.size) return null;
+
+      const clampedLength = Math.min(length, MAX_DOWNLOAD_CHUNK_BYTES, stats.size - offset);
+      const fd = openSync(resolved, 'r');
+      const buf = Buffer.alloc(clampedLength);
+      readSync(fd, buf, 0, buf.length, offset);
+      closeSync(fd);
+      return { data: buf, totalSize: stats.size };
+    } catch {
+      return null;
+    }
+  }
+
+  /** Delete a specific recording file. */
+  deleteRecording(filename: string): boolean {
+    const resolved = this.resolveRecordingPath(filename);
+    if (!resolved) return false;
+
+    try {
+      unlinkSync(resolved);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /** Delete all recording files. */
+  deleteAllRecordings(): number {
+    const files = this.listRecordings();
+    let deleted = 0;
+    for (const f of files) {
+      if (this.deleteRecording(f.filename)) deleted++;
+    }
+    return deleted;
+  }
+
+  /** Get the recordings directory path. */
+  getRecordingsDir(): string {
+    return this.recordingsDir;
+  }
+
+  // --- Private methods ---
+
+  /** Resolve and validate a recording filename to a safe absolute path. */
+  private resolveRecordingPath(filename: string): string | null {
+    const sanitized = path.basename(filename);
+    const filePath = path.join(this.recordingsDir, sanitized);
+    const resolved = path.resolve(filePath);
+
+    if (!resolved.startsWith(path.resolve(this.recordingsDir))) {
+      this.log.warn(`Path traversal attempt blocked: ${filename}`);
+      return null;
+    }
+    return resolved;
+  }
+
+  private stopSessionBySerial(serial: string): void {
+    const session = this.sessions.get(serial);
+    if (!session) return;
+
+    this.log.info(`Stopping raw debug recording for ${serial}...`);
+
+    // Capture reference before cleanup can null it
+    const proc = session.ffmpegProcess;
+
+    // Send 'q' to FFmpeg for graceful shutdown (finalizes MP4 container)
+    if (proc.stdin.writable) {
+      proc.stdin.write('q');
+    }
+
+    // Force kill after 5 seconds if it hasn't exited
+    const killTimer = setTimeout(() => {
+      this.log.warn(`Raw recording FFmpeg for ${serial} did not exit gracefully — killing.`);
+      proc.kill('SIGKILL');
+    }, 5000);
+
+    proc.on('exit', () => clearTimeout(killTimer));
+  }
+
+  private buildRawMuxArgs(
+    videoPort: number,
+    audioPort: number | null,
+    audioFormat: string | null,
+    outputPath: string,
+  ): string[] {
+    const args: string[] = [
+      '-hide_banner',
+      '-loglevel', 'warning',
+      '-use_wallclock_as_timestamps', '1',
+      '-f', 'h264',
+      '-i', `tcp://127.0.0.1:${videoPort}`,
+    ];
+
+    if (audioPort && audioFormat) {
+      args.push(
+        '-use_wallclock_as_timestamps', '1',
+        '-f', audioFormat,
+        '-i', `tcp://127.0.0.1:${audioPort}`,
+      );
+    }
+
+    args.push(
+      '-c', 'copy',
+      '-f', 'mp4',
+      '-movflags', 'frag_keyframe+empty_moov',
+      outputPath,
+    );
+
+    return args;
+  }
+
+  private async createInputServer(serial: string, input: Readable, label: string): Promise<number> {
+    const port = await pickPort({ type: 'tcp' });
+
+    return new Promise<number>((resolve) => {
+      const server = net.createServer((socket) => {
+        server.close();
+
+        const session = this.sessions.get(serial);
+        if (session) {
+          if (label === 'video') {
+            session.videoSocket = socket;
+          } else {
+            session.audioSocket = socket;
+          }
+        }
+
+        // Backpressure-aware piping
+        socket.on('drain', () => input.resume());
+
+        input.on('data', (chunk: Buffer) => {
+          if (socket.destroyed) return;
+          if (!socket.write(chunk)) {
+            input.pause();
+          }
+        });
+
+        input.on('end', () => {
+          if (!socket.destroyed) socket.end();
+        });
+        input.on('error', () => {
+          if (!socket.destroyed) socket.destroy();
+        });
+        socket.on('error', () => { /* ignore — handled by FFmpeg exit */ });
+        socket.on('close', () => {
+          const s = this.sessions.get(serial);
+          if (s) {
+            if (label === 'video') s.videoSocket = null;
+            else s.audioSocket = null;
+          }
+        });
+      });
+
+      server.on('error', () => { /* ignore */ });
+
+      const killTimeout = setTimeout(() => {
+        server.close();
+        this.log.warn(`Raw recording ${label} TCP server for ${serial} timed out — no FFmpeg connection.`);
+      }, 10_000);
+
+      server.listen(port, () => {
+        resolve(port);
+      });
+
+      server.on('connection', () => clearTimeout(killTimeout));
+    });
+  }
+
+  private cleanupSession(serial: string): void {
+    const session = this.sessions.get(serial);
+    if (!session) return;
+
+    if (session.videoSocket && !session.videoSocket.destroyed) {
+      session.videoSocket.destroy();
+    }
+    if (session.audioSocket && !session.audioSocket.destroyed) {
+      session.audioSocket.destroy();
+    }
+
+    this.sessions.delete(serial);
+  }
+
+  /** Remove oldest recordings to stay within per-camera and global limits. */
+  private enforceRetentionPolicy(serial: string): void {
+    try {
+      // Per-camera limit
+      const allFiles = this.listRecordings();
+      const cameraFiles = allFiles.filter(f => f.serial === serial)
+        .sort((a, b) => b.createdAt - a.createdAt);
+
+      if (cameraFiles.length > this.maxFilesPerCamera) {
+        const toDelete = cameraFiles.slice(this.maxFilesPerCamera);
+        for (const f of toDelete) {
+          this.log.debug(`Rotating old recording: ${f.filename}`);
+          this.deleteRecording(f.filename);
+        }
+      }
+
+      // Global size limit
+      let totalSize = 0;
+      const sortedByAge = this.listRecordings().sort((a, b) => b.createdAt - a.createdAt);
+      for (const f of sortedByAge) {
+        totalSize += f.sizeBytes;
+        if (totalSize > this.maxTotalBytes) {
+          this.log.debug(`Global cap exceeded — deleting: ${f.filename}`);
+          this.deleteRecording(f.filename);
+        }
+      }
+    } catch (err) {
+      this.log.warn(`Retention policy error: ${err}`);
+    }
+  }
+
+  private parseRecordingFilename(filename: string): DebugRecordingFile | null {
+    // Expected format: <serial>_<ISO-timestamp>_<type>.mp4
+    // or legacy: <serial>_<ISO-timestamp>.mp4 (processed, from existing debug recording)
+    // Timestamp in filename: 2024-03-26T14-30-00-000Z (colons and dots replaced with hyphens)
+    const match = filename.match(/^([A-Za-z0-9_-]+?)_(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:-\d{3}Z)?)(?:_(raw|processed))?\.mp4$/);
+    if (!match) return null;
+
+    const filePath = path.join(this.recordingsDir, filename);
+    try {
+      const stats = statSync(filePath);
+      // Restore ISO timestamp: only replace hyphens in the time portion (after the T)
+      const rawTs = match[2];
+      const tIdx = rawTs.indexOf('T');
+      const datePart = rawTs.substring(0, tIdx);
+      const timePart = rawTs.substring(tIdx + 1);
+      // Time part: 14-30-00-000Z → 14:30:00.000Z
+      const restoredTime = timePart
+        .replace(/^(\d{2})-(\d{2})-(\d{2})/, '$1:$2:$3')
+        .replace(/-(\d{3}Z)$/, '.$1');
+      const timestamp = `${datePart} ${restoredTime}`;
+
+      return {
+        filename,
+        serial: match[1],
+        timestamp,
+        type: (match[3] as 'raw' | 'processed') ?? 'processed',
+        sizeBytes: stats.size,
+        createdAt: stats.mtimeMs,
+      };
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/controller/LocalLivestreamManager.ts
+++ b/src/controller/LocalLivestreamManager.ts
@@ -4,6 +4,7 @@ import { CameraAccessory } from '../accessories/CameraAccessory.js';
 import { Deferred } from '../utils/utils.js';
 import { ILogObj, Logger } from 'tslog';
 import { PREBUFFER_DURATION_MS, PREBUFFER_ESTIMATED_BYTE_RATE } from '../settings.js';
+import { DebugRecordingManager } from './DebugRecordingManager.js';
 
 /** Internal state: streams plus a timestamp for dedup/reuse logic. */
 interface ActiveStream {
@@ -86,11 +87,15 @@ export class LocalLivestreamManager {
   private readonly eufyClient: EufySecurity;
   private readonly log: Logger<ILogObj>;
   private readonly serialNumber: string;
+  private readonly debugRecordingManager: DebugRecordingManager | null;
+  private readonly debugEnabled: boolean;
 
   constructor(camera: CameraAccessory) {
     this.eufyClient = camera.platform.eufyClient;
     this.serialNumber = camera.device.getSerial();
     this.log = camera.log;
+    this.debugEnabled = camera.platform.config.debugLivestream ?? false;
+    this.debugRecordingManager = camera.platform.debugRecordingManager ?? null;
 
     this.log.debug(`LocalLivestreamManager initialized for ${camera.device.getName()} (serial: ${this.serialNumber})`);
 
@@ -101,6 +106,8 @@ export class LocalLivestreamManager {
   /** Destroy active streams and reset state. */
   private destroyStreams(): void {
     this.stopBuffering();
+    // Stop raw debug recording before destroying streams
+    this.debugRecordingManager?.stopRawRecording(this.serialNumber);
     if (this.stationStream) {
       this.stationStream.audiostream.unpipe();
       this.stationStream.audiostream.destroy();
@@ -414,6 +421,19 @@ export class LocalLivestreamManager {
     // resolve), forkStream will drain the buffer immediately. If this is a
     // pre-warm with no consumers, the buffer accumulates until one arrives.
     this.startBuffering(videostream);
+
+    // Start raw debug recording if enabled — captures the P2P feed before any FFmpeg processing.
+    if (this.debugEnabled && this.debugRecordingManager) {
+      const rawVideoFork = new PassThrough();
+      const rawAudioFork = new PassThrough();
+      videostream.pipe(rawVideoFork);
+      audiostream.pipe(rawAudioFork);
+      rawVideoFork.on('close', () => videostream.unpipe(rawVideoFork));
+      rawAudioFork.on('close', () => audiostream.unpipe(rawAudioFork));
+      this.debugRecordingManager.startRawRecording(
+        this.serialNumber, rawVideoFork, rawAudioFork, metadata,
+      ).catch((err) => this.log.warn(`Raw debug recording failed to start: ${err}`));
+    }
 
     this.settlePending('resolve', this.stationStream);
   };

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -45,9 +45,13 @@ import { initLog, log, tsLogger, HAP, configureLogStreams } from './utils/utils.
 import { hasFdkAac, probeHardwareEncoder } from './utils/ffmpeg.js';
 import { AccessoriesStore } from './utils/accessoriesStore.js';
 import { LIB_VERSION } from './version.js';
+import { DebugRecordingManager } from './controller/DebugRecordingManager.js';
 
 export class EufySecurityPlatform implements DynamicPlatformPlugin {
   public eufyClient: EufySecurity = {} as EufySecurity;
+
+  /** Shared debug recording manager — created when debugLivestream is enabled. */
+  public debugRecordingManager: DebugRecordingManager | null = null;
 
   // this is used to track restored cached accessories
   public readonly accessories: PlatformAccessory[] = [];
@@ -97,6 +101,14 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
     this.probeHwOs();
 
     this.initConfig(config);
+
+    // Initialize debug recording manager when debugLivestream is enabled.
+    if (this.config.debugLivestream) {
+      this.debugRecordingManager = new DebugRecordingManager(
+        tsLogger,
+        this.eufyPath,
+      );
+    }
 
     this.configureLogger();
 

--- a/src/utils/ffmpeg.ts
+++ b/src/utils/ffmpeg.ts
@@ -801,9 +801,10 @@ export class FFmpegParameters {
      * @returns The absolute path to the recording file.
      */
     public setFileRecording(recordingDir: string, serial: string): string {
+        const sanitizedSerial = serial.replace(/[^A-Za-z0-9_-]/g, '');
         const ts = new Date().toISOString().replace(/[:.]/g, '-');
         mkdirSync(recordingDir, { recursive: true });
-        this.fileRecordingPath = path.join(recordingDir, `${serial}_${ts}.mp4`);
+        this.fileRecordingPath = path.join(recordingDir, `${sanitizedSerial}_${ts}_processed.mp4`);
         return this.fileRecordingPath;
     }
 


### PR DESCRIPTION
## Summary

- Add raw P2P stream capture alongside the existing processed recording when `debugLivestream` is enabled — lets users compare pre-FFmpeg vs post-FFmpeg output to narrow down streaming issues
- Raw capture uses codec-copy FFmpeg (zero re-encoding, minimal CPU) with per-camera session support for multi-camera setups
- Add Recordings UI page in Diagnostics with chunked downloads, progress bar, per-camera grouping, and delete actions
- Auto-rotate recordings: max 5 per camera, 500 MB global disk cap
- Sanitize serial numbers in filenames and validate paths to prevent traversal
- Chunked file downloads (256 KB) to avoid memory spikes on Raspberry Pi

## Test plan

- [ ] Enable Debug Logging + Debug Livestream in Diagnostics UI
- [ ] Restart plugin, open a camera in the Home app for ~10 seconds
- [ ] Navigate to Diagnostics > View Recordings
- [ ] Verify both `_raw.mp4` and `_processed.mp4` files appear
- [ ] Download a raw recording — verify it plays and shows the camera feed
- [ ] Download a processed recording — verify it plays
- [ ] Delete individual and all recordings
- [ ] Test with multiple cameras streaming simultaneously
- [ ] Verify disk rotation when exceeding 5 files per camera

🤖 Generated with [Claude Code](https://claude.com/claude-code)
