### PR TITLE
fix: debug recordings — audio, duration, session linking

### DIFF
--- a/homebridge-ui/public/views/recordings.js
+++ b/homebridge-ui/public/views/recordings.js
@@ -95,16 +95,16 @@ const RecordingsView = {
 
       if (btnDeleteAll) btnDeleteAll.style.display = '';
 
-      // Group by serial
-      const grouped = {};
+      // Group by serial, then by session (recordings sharing a timestamp are a pair)
+      const bySerial = {};
       for (const rec of recordings) {
-        if (!grouped[rec.serial]) grouped[rec.serial] = [];
-        grouped[rec.serial].push(rec);
+        if (!bySerial[rec.serial]) bySerial[rec.serial] = [];
+        bySerial[rec.serial].push(rec);
       }
 
       listContainer.innerHTML = '';
 
-      for (const [serial, recs] of Object.entries(grouped)) {
+      for (const [serial, recs] of Object.entries(bySerial)) {
         const section = document.createElement('div');
         section.className = 'settings-section';
 
@@ -113,73 +113,84 @@ const RecordingsView = {
         sectionTitle.textContent = serial;
         section.appendChild(sectionTitle);
 
-        const table = document.createElement('table');
-        table.className = 'table table-sm';
-        table.style.fontSize = '0.85rem';
+        // Group into sessions: recordings with matching timestamp are paired
+        const sessions = this._groupIntoSessions(recs);
 
-        const thead = document.createElement('thead');
-        thead.innerHTML = '<tr><th>Type</th><th>Date</th><th>Size</th><th></th></tr>';
-        table.appendChild(thead);
+        for (const session of sessions) {
+          const sessionDiv = document.createElement('div');
+          sessionDiv.className = 'mb-3';
 
-        const tbody = document.createElement('tbody');
+          // Session header with date
+          const sessionHeader = document.createElement('div');
+          sessionHeader.className = 'text-muted mb-1';
+          sessionHeader.style.fontSize = '0.8rem';
+          const firstRec = session[0];
+          const dateStr = firstRec.createdAtISO
+            ? new Date(firstRec.createdAtISO).toLocaleString()
+            : firstRec.timestamp || 'Unknown';
+          sessionHeader.textContent = dateStr;
+          sessionDiv.appendChild(sessionHeader);
 
-        for (const rec of recs) {
-          const tr = document.createElement('tr');
+          const table = document.createElement('table');
+          table.className = 'table table-sm mb-0';
+          table.style.fontSize = '0.85rem';
 
-          // Type badge
-          const tdType = document.createElement('td');
-          const badge = document.createElement('span');
-          badge.className = rec.type === 'raw'
-            ? 'badge bg-success'
-            : 'badge bg-primary';
-          badge.textContent = rec.type === 'raw' ? 'Raw' : 'Processed';
-          tdType.appendChild(badge);
-          tr.appendChild(tdType);
+          const tbody = document.createElement('tbody');
 
-          // Date
-          const tdDate = document.createElement('td');
-          tdDate.textContent = rec.createdAtISO
-            ? new Date(rec.createdAtISO).toLocaleString()
-            : rec.timestamp || 'Unknown';
-          tr.appendChild(tdDate);
+          for (const rec of session) {
+            const tr = document.createElement('tr');
 
-          // Size
-          const tdSize = document.createElement('td');
-          tdSize.textContent = rec.sizeMB + ' MB';
-          tr.appendChild(tdSize);
+            // Type badge
+            const tdType = document.createElement('td');
+            tdType.style.width = '90px';
+            const badge = document.createElement('span');
+            badge.className = rec.type === 'raw'
+              ? 'badge bg-success'
+              : 'badge bg-primary';
+            badge.textContent = rec.type === 'raw' ? 'Raw' : 'Processed';
+            tdType.appendChild(badge);
+            tr.appendChild(tdType);
 
-          // Actions
-          const tdActions = document.createElement('td');
-          tdActions.className = 'text-end';
+            // Size
+            const tdSize = document.createElement('td');
+            tdSize.textContent = rec.sizeMB + ' MB';
+            tr.appendChild(tdSize);
 
-          const btnDownload = document.createElement('button');
-          btnDownload.className = 'btn btn-outline-primary btn-sm me-1';
-          btnDownload.title = 'Download';
-          btnDownload.appendChild(Helpers.icon('download.svg'));
-          btnDownload.addEventListener('click', () => this._downloadRecording(container, rec.filename, rec.sizeBytes));
-          tdActions.appendChild(btnDownload);
+            // Actions
+            const tdActions = document.createElement('td');
+            tdActions.className = 'text-end';
 
-          const btnDelete = document.createElement('button');
-          btnDelete.className = 'btn btn-outline-danger btn-sm';
-          btnDelete.title = 'Delete';
-          btnDelete.appendChild(Helpers.icon('delete.svg'));
-          btnDelete.addEventListener('click', async () => {
-            try {
-              await Api.deleteDebugRecording(rec.filename);
-              homebridge.toast.success('Deleted ' + rec.filename);
-              await this._loadRecordings(container);
-            } catch (e) {
-              homebridge.toast.error('Delete failed: ' + (e.message || e));
-            }
-          });
-          tdActions.appendChild(btnDelete);
+            const btnDownload = document.createElement('button');
+            btnDownload.className = 'btn btn-outline-primary btn-sm me-1';
+            btnDownload.title = 'Download';
+            btnDownload.appendChild(Helpers.icon('download.svg'));
+            btnDownload.addEventListener('click', () => this._downloadRecording(container, rec.filename, rec.sizeBytes));
+            tdActions.appendChild(btnDownload);
 
-          tr.appendChild(tdActions);
-          tbody.appendChild(tr);
+            const btnDelete = document.createElement('button');
+            btnDelete.className = 'btn btn-outline-danger btn-sm';
+            btnDelete.title = 'Delete';
+            btnDelete.appendChild(Helpers.icon('delete.svg'));
+            btnDelete.addEventListener('click', async () => {
+              try {
+                await Api.deleteDebugRecording(rec.filename);
+                homebridge.toast.success('Deleted ' + rec.filename);
+                await this._loadRecordings(container);
+              } catch (e) {
+                homebridge.toast.error('Delete failed: ' + (e.message || e));
+              }
+            });
+            tdActions.appendChild(btnDelete);
+
+            tr.appendChild(tdActions);
+            tbody.appendChild(tr);
+          }
+
+          table.appendChild(tbody);
+          sessionDiv.appendChild(table);
+          section.appendChild(sessionDiv);
         }
 
-        table.appendChild(tbody);
-        section.appendChild(table);
         listContainer.appendChild(section);
       }
     } catch (e) {
@@ -262,6 +273,25 @@ const RecordingsView = {
       this._downloadInProgress = false;
       if (progressArea) progressArea.innerHTML = '';
     }
+  },
+
+  /**
+   * Group recordings into sessions by extracting the timestamp portion from
+   * the filename. Recordings sharing a timestamp are a raw/processed pair.
+   */
+  _groupIntoSessions(recs) {
+    const map = {};
+    for (const rec of recs) {
+      // Filename: <serial>_<timestamp>_<type>.mp4 — extract timestamp as session key
+      const match = rec.filename.match(/^[A-Za-z0-9_-]+?_(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:-\d{3}Z)?)_/);
+      const key = match ? match[1] : rec.filename;
+      if (!map[key]) map[key] = [];
+      map[key].push(rec);
+    }
+    // Sort sessions by newest first, within each session: raw before processed
+    return Object.values(map)
+      .sort((a, b) => (b[0].createdAt || 0) - (a[0].createdAt || 0))
+      .map(session => session.sort((a) => (a.type === 'raw' ? -1 : 1)));
   },
 
   _confirmDeleteAll(container) {

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -1328,6 +1328,7 @@ class UiServer extends HomebridgePluginUiServer {
             return {
               filename,
               serial: match ? match[1] : 'unknown',
+              timestamp: match ? match[2] : '',
               type: match && match[3] ? match[3] : 'processed',
               sizeBytes: stats.size,
               sizeMB: (stats.size / (1024 * 1024)).toFixed(1),

--- a/src/controller/DebugRecordingManager.ts
+++ b/src/controller/DebugRecordingManager.ts
@@ -81,6 +81,7 @@ export class DebugRecordingManager {
     videostream: Readable,
     audiostream: Readable,
     metadata: StreamMetadata,
+    sessionId?: string,
   ): Promise<string | null> {
     const sanitizedSerial = serial.replace(/[^A-Za-z0-9_-]/g, '');
 
@@ -89,7 +90,7 @@ export class DebugRecordingManager {
       return null;
     }
 
-    const ts = new Date().toISOString().replace(/[:.]/g, '-');
+    const ts = sessionId ?? new Date().toISOString().replace(/[:.]/g, '-');
     const filename = `${sanitizedSerial}_${ts}_raw.mp4`;
     const outputPath = path.join(this.recordingsDir, filename);
 
@@ -314,24 +315,16 @@ export class DebugRecordingManager {
           }
         }
 
-        // Backpressure-aware piping
-        socket.on('drain', () => input.resume());
+        // pipe() automatically drains any data buffered in the PassThrough
+        // while FFmpeg was starting up, then continues flowing with backpressure.
+        input.pipe(socket);
 
-        input.on('data', (chunk: Buffer) => {
-          if (socket.destroyed) return;
-          if (!socket.write(chunk)) {
-            input.pause();
-          }
-        });
-
-        input.on('end', () => {
-          if (!socket.destroyed) socket.end();
-        });
         input.on('error', () => {
           if (!socket.destroyed) socket.destroy();
         });
-        socket.on('error', () => { /* ignore — handled by FFmpeg exit */ });
+        socket.on('error', () => { input.unpipe(socket); });
         socket.on('close', () => {
+          input.unpipe(socket);
           const s = this.sessions.get(serial);
           if (s) {
             if (label === 'video') s.videoSocket = null;

--- a/src/controller/LocalLivestreamManager.ts
+++ b/src/controller/LocalLivestreamManager.ts
@@ -12,6 +12,8 @@ interface ActiveStream {
   audiostream: Readable;
   metadata: StreamMetadata;
   createdAt: number;
+  /** Shared ID linking raw + processed debug recordings from the same session. */
+  sessionId: string;
 }
 
 /** Data returned to consumers — only the streams they need. */
@@ -221,6 +223,11 @@ export class LocalLivestreamManager {
     return this.stationStream !== null || this.pending !== null;
   }
 
+  /** Session ID for the current debug recording pair (raw + processed). */
+  public getSessionId(): string | null {
+    return this.stationStream?.sessionId ?? null;
+  }
+
   /**
    * Pre-warm the P2P livestream without creating a consumer fork.
    * The stream will be kept alive by the STOP_GRACE_MS timer once established.
@@ -415,7 +422,8 @@ export class LocalLivestreamManager {
     this.log.debug(`${station.getName()} P2P livestream for ${device.getName()} started.`);
     this.log.debug('Stream metadata:', JSON.stringify(metadata));
 
-    this.stationStream = { videostream, audiostream, metadata, createdAt: Date.now() };
+    const sessionId = new Date().toISOString().replace(/[:.]/g, '-');
+    this.stationStream = { videostream, audiostream, metadata, createdAt: Date.now(), sessionId };
 
     // Start prebuffering video data. If a consumer is already waiting (pending
     // resolve), forkStream will drain the buffer immediately. If this is a
@@ -423,15 +431,17 @@ export class LocalLivestreamManager {
     this.startBuffering(videostream);
 
     // Start raw debug recording if enabled — captures the P2P feed before any FFmpeg processing.
+    // Large highWaterMark lets the fork buffer data while FFmpeg starts up,
+    // preventing backpressure from stalling the source P2P stream.
     if (this.debugEnabled && this.debugRecordingManager) {
-      const rawVideoFork = new PassThrough();
-      const rawAudioFork = new PassThrough();
+      const rawVideoFork = new PassThrough({ highWaterMark: 4 * 1024 * 1024 });
+      const rawAudioFork = new PassThrough({ highWaterMark: 256 * 1024 });
       videostream.pipe(rawVideoFork);
       audiostream.pipe(rawAudioFork);
       rawVideoFork.on('close', () => videostream.unpipe(rawVideoFork));
       rawAudioFork.on('close', () => audiostream.unpipe(rawAudioFork));
       this.debugRecordingManager.startRawRecording(
-        this.serialNumber, rawVideoFork, rawAudioFork, metadata,
+        this.serialNumber, rawVideoFork, rawAudioFork, metadata, sessionId,
       ).catch((err) => this.log.warn(`Raw debug recording failed to start: ${err}`));
     }
 

--- a/src/controller/streamingDelegate.ts
+++ b/src/controller/streamingDelegate.ts
@@ -171,7 +171,8 @@ export class StreamingDelegate implements CameraStreamingDelegate {
       // Record a parallel copy of the video stream to disk for debugging.
       if (this.camera.platform.config.debugLivestream) {
         const recDir = this.camera.platform.eufyPath + '/recordings';
-        const recPath = videoParams.setFileRecording(recDir, this.device.getSerial());
+        const sessionId = this.localLivestreamManager.getSessionId() ?? undefined;
+        const recPath = videoParams.setFileRecording(recDir, this.device.getSerial(), sessionId);
         this.log.info(`Recording stream to ${recPath}`);
       }
 

--- a/src/utils/ffmpeg.ts
+++ b/src/utils/ffmpeg.ts
@@ -800,9 +800,9 @@ export class FFmpegParameters {
      *
      * @returns The absolute path to the recording file.
      */
-    public setFileRecording(recordingDir: string, serial: string): string {
+    public setFileRecording(recordingDir: string, serial: string, sessionId?: string): string {
         const sanitizedSerial = serial.replace(/[^A-Za-z0-9_-]/g, '');
-        const ts = new Date().toISOString().replace(/[:.]/g, '-');
+        const ts = sessionId ?? new Date().toISOString().replace(/[:.]/g, '-');
         mkdirSync(recordingDir, { recursive: true });
         this.fileRecordingPath = path.join(recordingDir, `${sanitizedSerial}_${ts}_processed.mp4`);
         return this.fileRecordingPath;
@@ -1006,7 +1006,11 @@ export class FFmpegParameters {
         // Uses codec copy so there is virtually no extra CPU cost.
         const recPath = parameters[0].fileRecordingPath;
         if (recPath) {
-            params.push('-map 0:v -c:v copy -an -f mp4 -movflags frag_keyframe+empty_moov');
+            const hasAudio = parameters.length > 1;
+            const mapArgs = hasAudio
+                ? '-map 0:v -map 1:a -c copy'
+                : '-map 0:v -c:v copy';
+            params.push(`${mapArgs} -f mp4 -movflags frag_keyframe+empty_moov`);
             params.push(recPath);
         }
 


### PR DESCRIPTION
## Summary

Fix three bugs in the debug livestream recording feature:

- **No audio in processed recordings** — the FFmpeg file-recording tee used `-an` which stripped audio; now maps both video and audio with codec copy when audio input exists
- **Raw recordings truncated to ~0.1s** — race condition where `createInputServer` only forwarded data after FFmpeg connected to TCP; now uses `pipe()` which drains buffered data on connection. PassThrough forks use large highWaterMark (4MB video, 256KB audio) so the source P2P stream isn't blocked during FFmpeg startup
- **Raw and processed not linked** — each generated its own timestamp; now a shared session ID is created when the P2P stream starts and passed to both recordings so filenames match
- **UI groups by session** — recordings with the same timestamp are shown as a raw/processed pair instead of flat list

## Test plan

- [ ] Enable Debug Livestream, restart plugin, stream a camera ~15s
- [ ] Navigate to Diagnostics > View Recordings
- [ ] Verify raw and processed appear paired with matching timestamps
- [ ] Download both — verify audio present, durations similar
- [ ] `ffprobe` both files: should show video + audio tracks

🤖 Generated with [Claude Code](https://claude.com/claude-code)
