### PR TITLE
fix: debug recording duration, timestamps, and UI redesign

### DIFF
--- a/homebridge-ui/public/views/recordings.js
+++ b/homebridge-ui/public/views/recordings.js
@@ -34,7 +34,7 @@ const RecordingsView = {
     const info = document.createElement('div');
     info.className = 'alert alert-info';
     info.style.fontSize = '0.85rem';
-    info.innerHTML = Helpers.iconHtml('info.svg') + ' <strong>Raw</strong> recordings capture the P2P feed directly from the camera (before FFmpeg). <strong>Processed</strong> recordings capture the re-encoded stream sent to HomeKit. Compare them to narrow down where an issue originates.';
+    info.innerHTML = Helpers.iconHtml('info.svg') + ' <strong>Raw</strong> = P2P feed (audio + video, before FFmpeg). <strong>Processed</strong> = re-encoded video sent to HomeKit. Compare to find where an issue originates.';
     container.appendChild(info);
 
     // Toolbar row (Reload + Delete All)
@@ -95,7 +95,7 @@ const RecordingsView = {
 
       if (btnDeleteAll) btnDeleteAll.style.display = '';
 
-      // Group by serial, then by session (recordings sharing a timestamp are a pair)
+      // Group by serial, then by session
       const bySerial = {};
       for (const rec of recordings) {
         if (!bySerial[rec.serial]) bySerial[rec.serial] = [];
@@ -117,78 +117,74 @@ const RecordingsView = {
         const sessions = this._groupIntoSessions(recs);
 
         for (const session of sessions) {
-          const sessionDiv = document.createElement('div');
-          sessionDiv.className = 'mb-3';
-
-          // Session header with date
-          const sessionHeader = document.createElement('div');
-          sessionHeader.className = 'text-muted mb-1';
-          sessionHeader.style.fontSize = '0.8rem';
+          const raw = session.find(r => r.type === 'raw');
+          const processed = session.find(r => r.type === 'processed');
           const firstRec = session[0];
+
+          const row = document.createElement('div');
+          row.className = 'd-flex align-items-center justify-content-between py-2 border-bottom';
+          row.style.fontSize = '0.85rem';
+
+          // Left: date and size info
+          const leftCol = document.createElement('div');
           const dateStr = firstRec.createdAtISO
             ? new Date(firstRec.createdAtISO).toLocaleString()
             : firstRec.timestamp || 'Unknown';
-          sessionHeader.textContent = dateStr;
-          sessionDiv.appendChild(sessionHeader);
+          const sizeInfo = session.map(r => {
+            const label = r.type === 'raw' ? 'R' : 'P';
+            return label + ':' + r.sizeMB + 'MB';
+          }).join(' / ');
 
-          const table = document.createElement('table');
-          table.className = 'table table-sm mb-0';
-          table.style.fontSize = '0.85rem';
+          const dateLine = document.createElement('div');
+          dateLine.textContent = dateStr;
+          const sizeLine = document.createElement('small');
+          sizeLine.className = 'text-muted';
+          sizeLine.textContent = sizeInfo;
+          leftCol.appendChild(dateLine);
+          leftCol.appendChild(sizeLine);
 
-          const tbody = document.createElement('tbody');
+          // Right: action buttons
+          const rightCol = document.createElement('div');
+          rightCol.className = 'd-flex align-items-center gap-1';
 
-          for (const rec of session) {
-            const tr = document.createElement('tr');
-
-            // Type badge
-            const tdType = document.createElement('td');
-            tdType.style.width = '90px';
-            const badge = document.createElement('span');
-            badge.className = rec.type === 'raw'
-              ? 'badge bg-success'
-              : 'badge bg-primary';
-            badge.textContent = rec.type === 'raw' ? 'Raw' : 'Processed';
-            tdType.appendChild(badge);
-            tr.appendChild(tdType);
-
-            // Size
-            const tdSize = document.createElement('td');
-            tdSize.textContent = rec.sizeMB + ' MB';
-            tr.appendChild(tdSize);
-
-            // Actions
-            const tdActions = document.createElement('td');
-            tdActions.className = 'text-end';
-
-            const btnDownload = document.createElement('button');
-            btnDownload.className = 'btn btn-outline-primary btn-sm me-1';
-            btnDownload.title = 'Download';
-            btnDownload.appendChild(Helpers.icon('download.svg'));
-            btnDownload.addEventListener('click', () => this._downloadRecording(container, rec.filename, rec.sizeBytes));
-            tdActions.appendChild(btnDownload);
-
-            const btnDelete = document.createElement('button');
-            btnDelete.className = 'btn btn-outline-danger btn-sm';
-            btnDelete.title = 'Delete';
-            btnDelete.appendChild(Helpers.icon('delete.svg'));
-            btnDelete.addEventListener('click', async () => {
-              try {
-                await Api.deleteDebugRecording(rec.filename);
-                homebridge.toast.success('Deleted ' + rec.filename);
-                await this._loadRecordings(container);
-              } catch (e) {
-                homebridge.toast.error('Delete failed: ' + (e.message || e));
-              }
-            });
-            tdActions.appendChild(btnDelete);
-
-            tr.appendChild(tdActions);
-            tbody.appendChild(tr);
+          if (raw) {
+            const btnRaw = document.createElement('button');
+            btnRaw.className = 'btn btn-outline-success btn-sm';
+            btnRaw.title = 'Download Raw';
+            btnRaw.textContent = 'Raw';
+            btnRaw.addEventListener('click', () => this._downloadRecording(container, raw.filename, raw.sizeBytes));
+            rightCol.appendChild(btnRaw);
           }
 
-          table.appendChild(tbody);
-          sessionDiv.appendChild(table);
-          section.appendChild(sessionDiv);
+          if (processed) {
+            const btnProc = document.createElement('button');
+            btnProc.className = 'btn btn-outline-primary btn-sm';
+            btnProc.title = 'Download Processed';
+            btnProc.textContent = 'Processed';
+            btnProc.addEventListener('click', () => this._downloadRecording(container, processed.filename, processed.sizeBytes));
+            rightCol.appendChild(btnProc);
+          }
+
+          const btnDelete = document.createElement('button');
+          btnDelete.className = 'btn btn-outline-danger btn-sm';
+          btnDelete.title = 'Delete';
+          btnDelete.appendChild(Helpers.icon('delete.svg'));
+          btnDelete.addEventListener('click', async () => {
+            try {
+              for (const rec of session) {
+                await Api.deleteDebugRecording(rec.filename);
+              }
+              homebridge.toast.success('Deleted ' + session.length + ' file(s).');
+              await this._loadRecordings(container);
+            } catch (e) {
+              homebridge.toast.error('Delete failed: ' + (e.message || e));
+            }
+          });
+          rightCol.appendChild(btnDelete);
+
+          row.appendChild(leftCol);
+          row.appendChild(rightCol);
+          section.appendChild(row);
         }
 
         listContainer.appendChild(section);

--- a/src/controller/DebugRecordingManager.ts
+++ b/src/controller/DebugRecordingManager.ts
@@ -273,17 +273,22 @@ export class DebugRecordingManager {
     audioFormat: string | null,
     outputPath: string,
   ): string[] {
+    // Use genpts instead of wallclock timestamps — raw P2P data is often
+    // buffered in the PassThrough fork while FFmpeg starts up. Wallclock
+    // timestamps compress the burst into <1 s; genpts assigns monotonically
+    // increasing PTS at the assumed frame rate, producing correct duration.
     const args: string[] = [
       '-hide_banner',
       '-loglevel', 'warning',
-      '-use_wallclock_as_timestamps', '1',
+      '-fflags', '+genpts',
+      '-r', '15',
       '-f', 'h264',
       '-i', `tcp://127.0.0.1:${videoPort}`,
     ];
 
     if (audioPort && audioFormat) {
       args.push(
-        '-use_wallclock_as_timestamps', '1',
+        '-fflags', '+genpts',
         '-f', audioFormat,
         '-i', `tcp://127.0.0.1:${audioPort}`,
       );

--- a/src/controller/LocalLivestreamManager.ts
+++ b/src/controller/LocalLivestreamManager.ts
@@ -431,18 +431,20 @@ export class LocalLivestreamManager {
     this.startBuffering(videostream);
 
     // Start raw debug recording if enabled — captures the P2P feed before any FFmpeg processing.
-    // Large highWaterMark lets the fork buffer data while FFmpeg starts up,
-    // preventing backpressure from stalling the source P2P stream.
+    // Piping source→fork is deferred until startRawRecording resolves (TCP servers
+    // listening, FFmpeg spawned). This prevents buffered data from bursting into
+    // FFmpeg all at once, which would cause incorrect timestamps and ~0s duration.
     if (this.debugEnabled && this.debugRecordingManager) {
-      const rawVideoFork = new PassThrough({ highWaterMark: 4 * 1024 * 1024 });
-      const rawAudioFork = new PassThrough({ highWaterMark: 256 * 1024 });
-      videostream.pipe(rawVideoFork);
-      audiostream.pipe(rawAudioFork);
-      rawVideoFork.on('close', () => videostream.unpipe(rawVideoFork));
-      rawAudioFork.on('close', () => audiostream.unpipe(rawAudioFork));
+      const rawVideoFork = new PassThrough();
+      const rawAudioFork = new PassThrough();
       this.debugRecordingManager.startRawRecording(
         this.serialNumber, rawVideoFork, rawAudioFork, metadata, sessionId,
-      ).catch((err) => this.log.warn(`Raw debug recording failed to start: ${err}`));
+      ).then(() => {
+        videostream.pipe(rawVideoFork);
+        audiostream.pipe(rawAudioFork);
+        rawVideoFork.on('close', () => videostream.unpipe(rawVideoFork));
+        rawAudioFork.on('close', () => audiostream.unpipe(rawAudioFork));
+      }).catch((err) => this.log.warn(`Raw debug recording failed to start: ${err}`));
     }
 
     this.settlePending('resolve', this.stationStream);

--- a/src/utils/ffmpeg.ts
+++ b/src/utils/ffmpeg.ts
@@ -1003,14 +1003,11 @@ export class FFmpegParameters {
         }
 
         // Append a parallel file-recording output when configured.
-        // Uses codec copy so there is virtually no extra CPU cost.
+        // Video-only copy — for P2P streams video and audio use separate
+        // FFmpeg processes, so only the video track is available here.
         const recPath = parameters[0].fileRecordingPath;
         if (recPath) {
-            const hasAudio = parameters.length > 1;
-            const mapArgs = hasAudio
-                ? '-map 0:v -map 1:a -c copy'
-                : '-map 0:v -c:v copy';
-            params.push(`${mapArgs} -f mp4 -movflags frag_keyframe+empty_moov`);
+            params.push('-map 0:v -c:v copy -f mp4 -movflags frag_keyframe+empty_moov');
             params.push(recPath);
         }
 


### PR DESCRIPTION
## Summary

Fixes three issues with debug livestream recordings:

- **Raw recording duration**: Recordings captured only ~0.07s because P2P data buffered in the PassThrough fork while FFmpeg started up, then burst out with wallclock timestamps compressing everything to near-zero duration. Fixed by using `genpts` for monotonic PTS generation and deferring the source→fork pipe until the recording FFmpeg process is spawned
- **Processed recording audio**: Removed dead `hasAudio` code path — P2P streaming uses separate FFmpeg processes for video and audio, so the video process file-tee can never include audio. Simplified to explicit video-only copy
- **UI redesign**: Single row per recording session with [Raw] and [Processed] download buttons and one delete button that removes all files in the session

## Test plan

- [ ] Enable Debug Livestream, restart plugin, open camera in Home app for ~15s
- [ ] Check recordings list: raw and processed should appear as paired session on one row
- [ ] Download raw — verify duration matches stream time, has audio+video tracks
- [ ] Download processed — verify duration matches, video-only
- [ ] Delete button removes both files in the session
- [ ] Delete All still works
