### PR TITLE
fix: raw recording crash from ADTS AAC and misrouted logs

### DIFF
--- a/src/controller/DebugRecordingManager.ts
+++ b/src/controller/DebugRecordingManager.ts
@@ -294,8 +294,12 @@ export class DebugRecordingManager {
       );
     }
 
+    args.push('-c', 'copy');
+    // Raw AAC from P2P is ADTS-wrapped; MP4 container requires raw AAC.
+    if (audioPort && audioFormat) {
+      args.push('-bsf:a', 'aac_adtstoasc');
+    }
     args.push(
-      '-c', 'copy',
       '-f', 'mp4',
       '-movflags', 'frag_keyframe+empty_moov',
       outputPath,

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -105,10 +105,9 @@ export class EufySecurityPlatform implements DynamicPlatformPlugin {
     this.configureLogger();
 
     // Initialize debug recording manager when debugLivestream is enabled.
-    // Must be after configureLogger() so tsLogger is ready.
     if (this.config.debugLivestream) {
       this.debugRecordingManager = new DebugRecordingManager(
-        tsLogger,
+        log,
         this.eufyPath,
       );
     }


### PR DESCRIPTION
## Summary

- **Raw recording ADTS crash**: Raw recordings crashed immediately (exit 255) because P2P audio is ADTS-wrapped AAC, which the MP4 muxer rejects. FFmpeg error: `Malformed AAC bitstream detected: use the audio bitstream filter 'aac_adtstoasc'`. Fixed by adding `-bsf:a aac_adtstoasc` to convert ADTS headers to the raw format MP4 requires.

- **Misrouted logs**: DebugRecordingManager used `tsLogger` which routes to `eufy-lib.log` (the library log). Changed to `log` so recording messages appear in `eufy-security.log` where they're visible in diagnostics.

## Test plan

- [ ] Enable Debug Livestream, restart plugin, open camera in Home app for ~15s
- [ ] Check `eufy-security.log` — should now show "Starting raw debug recording" messages
- [ ] Download raw recording — verify it has proper duration and both audio+video tracks
- [ ] `ffprobe` the raw file: should show h264 video + aac audio streams
