### PR TITLE
fix: destroy raw recording forks on FFmpeg exit to prevent backpressure stall

### DIFF
--- a/homebridge-ui/public/views/recordings.js
+++ b/homebridge-ui/public/views/recordings.js
@@ -250,17 +250,15 @@ const RecordingsView = {
         pos += chunk.length;
       }
 
-      let binary = '';
-      for (let i = 0; i < combined.length; i++) {
-        binary += String.fromCharCode(combined[i]);
-      }
-      const base64 = btoa(binary);
+      const blob = new Blob([combined], { type: 'application/octet-stream' });
+      const url = URL.createObjectURL(blob);
       const a = document.createElement('a');
-      a.href = 'data:application/octet-stream;base64,' + base64;
+      a.href = url;
       a.download = filename;
       document.body.appendChild(a);
       a.click();
       document.body.removeChild(a);
+      URL.revokeObjectURL(url);
 
       homebridge.toast.success('Downloaded: ' + filename);
     } catch (e) {

--- a/src/controller/DebugRecordingManager.ts
+++ b/src/controller/DebugRecordingManager.ts
@@ -259,7 +259,7 @@ export class DebugRecordingManager {
 
     // Send 'q' to FFmpeg for graceful shutdown (finalizes MP4 container)
     if (proc.stdin.writable) {
-      proc.stdin.write('q');
+      proc.stdin.write('q\n');
     }
 
     // Force kill after 5 seconds if it hasn't exited


### PR DESCRIPTION
## Summary

Comprehensive fix for the remaining debug recording issues after the ADTS crash fix in #892.

### 1. Dead-fork backpressure stall (critical)

When raw recording FFmpeg exited, the PassThrough forks piped from the source P2P streams were never destroyed. They filled their 16KB internal buffer, applied permanent backpressure on the source `videostream`, and starved ALL downstream consumers — including the streaming FFmpeg and its file-recording tee. This caused the 36-byte processed recording and could freeze the HomeKit livestream.

**Fix**: Track fork references in the recording session. Destroy them in `cleanupSession()` and in the TCP socket `close` handler. Destroying the forks fires their `close` event, which triggers `unpipe()` in LocalLivestreamManager — releasing the source stream.

### 2. FFmpeg graceful quit missing newline

`proc.stdin.write('q')` → `proc.stdin.write('q\n')`. Without the newline, FFmpeg never receives the quit command and always gets SIGKILL'd after 5s, potentially truncating the MP4 container.

### 3. Download memory efficiency

Replaced `btoa()` + data URI download with `Blob` + `URL.createObjectURL`. The previous approach created a binary string + base64 copy in memory (3x the file size), which would crash the browser for large recordings.

## Test plan

- [ ] Enable Debug Livestream, restart plugin, open camera in Home app for ~15s
- [ ] Check recordings list — both raw and processed should appear with matching session IDs
- [ ] Download raw recording — verify proper duration and audio+video tracks (`ffprobe`)
- [ ] Download processed recording — verify proper duration and video track
- [ ] HomeKit livestream should remain stable and not freeze during recording
- [ ] Stop the stream, verify raw recording FFmpeg exits cleanly (check `eufy-security.log`)
- [ ] Download a recording from the UI — verify no browser freeze/crash
