### PR TITLE
fix: raw recording timestamps, graceful shutdown, and remove redundant P2P file tee

### DIFF
--- a/src/controller/DebugRecordingManager.ts
+++ b/src/controller/DebugRecordingManager.ts
@@ -254,19 +254,22 @@ export class DebugRecordingManager {
 
     this.log.info(`Stopping raw debug recording for ${serial}...`);
 
-    // Capture reference before cleanup can null it
-    const proc = session.ffmpegProcess;
-
-    // Send 'q' to FFmpeg for graceful shutdown (finalizes MP4 container)
-    if (proc.stdin.writable) {
-      proc.stdin.write('q\n');
+    // Close TCP sockets to signal EOF to FFmpeg. This is the only reliable
+    // way to stop FFmpeg when it reads from TCP — stdin 'q' is ignored
+    // because FFmpeg is blocked in the socket read loop. Socket EOF causes
+    // FFmpeg to finalize the MP4 container and exit cleanly.
+    if (session.videoSocket && !session.videoSocket.destroyed) {
+      session.videoSocket.destroy();
+    }
+    if (session.audioSocket && !session.audioSocket.destroyed) {
+      session.audioSocket.destroy();
     }
 
-    // Force kill after 5 seconds if it hasn't exited
+    const proc = session.ffmpegProcess;
     const killTimer = setTimeout(() => {
-      this.log.warn(`Raw recording FFmpeg for ${serial} did not exit gracefully — killing.`);
+      this.log.warn(`Raw recording FFmpeg for ${serial} did not exit after socket close — killing.`);
       proc.kill('SIGKILL');
-    }, 5000);
+    }, 3000);
 
     proc.on('exit', () => clearTimeout(killTimer));
   }
@@ -277,22 +280,21 @@ export class DebugRecordingManager {
     audioFormat: string | null,
     outputPath: string,
   ): string[] {
-    // Use genpts instead of wallclock timestamps — raw P2P data is often
-    // buffered in the PassThrough fork while FFmpeg starts up. Wallclock
-    // timestamps compress the burst into <1 s; genpts assigns monotonically
-    // increasing PTS at the assumed frame rate, producing correct duration.
+    // Wallclock timestamps are correct here because source→fork piping is
+    // deferred until TCP servers are listening and FFmpeg is spawned (no
+    // burst of buffered data). Frames arrive in real-time and get accurate
+    // PTS. Initial frames before SPS/PPS are discarded by FFmpeg (harmless).
     const args: string[] = [
       '-hide_banner',
       '-loglevel', 'warning',
-      '-fflags', '+genpts',
-      '-r', '15',
+      '-use_wallclock_as_timestamps', '1',
       '-f', 'h264',
       '-i', `tcp://127.0.0.1:${videoPort}`,
     ];
 
     if (audioPort && audioFormat) {
       args.push(
-        '-fflags', '+genpts',
+        '-use_wallclock_as_timestamps', '1',
         '-f', audioFormat,
         '-i', `tcp://127.0.0.1:${audioPort}`,
       );

--- a/src/controller/streamingDelegate.ts
+++ b/src/controller/streamingDelegate.ts
@@ -169,11 +169,14 @@ export class StreamingDelegate implements CameraStreamingDelegate {
       const isP2P = await this.configureStreamInput(videoParams, audioParams);
 
       // Record a parallel copy of the video stream to disk for debugging.
-      if (this.camera.platform.config.debugLivestream) {
+      // For P2P cameras, the raw recording (DebugRecordingManager) captures
+      // both video+audio from the P2P feed — the file tee here would only
+      // duplicate the raw video without audio. For RTSP cameras, this tee
+      // is the only recording mechanism since DebugRecordingManager is P2P-only.
+      if (this.camera.platform.config.debugLivestream && !isP2P) {
         const recDir = this.camera.platform.eufyPath + '/recordings';
-        const sessionId = this.localLivestreamManager.getSessionId() ?? undefined;
-        const recPath = videoParams.setFileRecording(recDir, this.device.getSerial(), sessionId);
-        this.log.info(`Recording stream to ${recPath}`);
+        const recPath = videoParams.setFileRecording(recDir, this.device.getSerial());
+        this.log.info(`Recording RTSP stream to ${recPath}`);
       }
 
       await this.startFFmpegProcesses(activeSession, videoParams, audioParams, request, callback, isP2P);


### PR DESCRIPTION
## Summary

Comprehensive fix for the three remaining debug recording issues after #892 (ADTS) and #893 (backpressure).

### 1. Raw recording timestamps — wrong duration

The `+genpts -r 15` approach created synthetic timestamps with a 2-second gap at the start (FFmpeg's h264 demuxer probing for SPS/PPS). VLC showed ~4s of actual content spread across a 17.9s container.

Switched back to `-use_wallclock_as_timestamps 1`. This was originally rejected because buffered data arrived in a burst, but deferred piping (merged in #891) eliminates the burst — data now flows in real-time after FFmpeg's TCP servers are ready.

### 2. Graceful shutdown — FFmpeg always got SIGKILL

`stdin.write('q\n')` is ignored when FFmpeg reads from TCP sockets (it's blocked in the socket read loop, not monitoring stdin). FFmpeg was always force-killed after 5s, potentially corrupting the MP4 container.

Now destroys the TCP sockets to signal EOF. FFmpeg detects socket close, finalizes the container, and exits cleanly.

### 3. Remove processed file tee for P2P cameras

The processed file tee (`-map 0:v -c:v copy`) on the streaming FFmpeg was broken for P2P:
- Copies raw P2P input (2560x1440), NOT the encoded 720p HomeKit stream
- No audio (P2P audio is a separate FFmpeg process)
- HomeKit session cycling overwrites the file (probe→stop→restart pattern)
- Redundant with the raw recording which already captures video+audio

Kept the file tee for RTSP cameras where it's the only recording mechanism (DebugRecordingManager is P2P-only).

## Test plan

- [ ] Enable Debug Livestream, restart plugin, stream a P2P camera in Home app for ~10s
- [ ] Download raw recording — verify duration matches actual stream time
- [ ] `ffprobe` the raw file: video duration and audio duration should roughly match
- [ ] Check `eufy-security.log` — FFmpeg should exit cleanly (exit code 0, not "killing")
- [ ] No "processed" recording should appear for P2P cameras
- [ ] Verify HomeKit livestream is stable during recording
