### PR TITLE
feat: tag debug recordings with trigger type (HKSV vs livestream)

### DIFF
--- a/homebridge-ui/public/views/recordings.js
+++ b/homebridge-ui/public/views/recordings.js
@@ -34,7 +34,7 @@ const RecordingsView = {
     const info = document.createElement('div');
     info.className = 'alert alert-info';
     info.style.fontSize = '0.85rem';
-    info.innerHTML = Helpers.iconHtml('info.svg') + ' <strong>Raw</strong> = P2P feed (audio + video, before FFmpeg). <strong>Processed</strong> = re-encoded video sent to HomeKit. Compare to find where an issue originates.';
+    info.innerHTML = Helpers.iconHtml('info.svg') + ' <strong>HKSV</strong> = recording triggered by motion (HomeKit Secure Video). <strong>Livestream</strong> = manual stream from Home app. <strong>Processed</strong> = RTSP re-encoded stream.';
     container.appendChild(info);
 
     // Toolbar row (Reload + Delete All)
@@ -117,8 +117,6 @@ const RecordingsView = {
         const sessions = this._groupIntoSessions(recs);
 
         for (const session of sessions) {
-          const raw = session.find(r => r.type === 'raw');
-          const processed = session.find(r => r.type === 'processed');
           const firstRec = session[0];
 
           const row = document.createElement('div');
@@ -130,8 +128,9 @@ const RecordingsView = {
           const dateStr = firstRec.createdAtISO
             ? new Date(firstRec.createdAtISO).toLocaleString()
             : firstRec.timestamp || 'Unknown';
+          const typeLabels = { hksv: 'HKSV', livestream: 'Live', processed: 'Proc', raw: 'Raw' };
           const sizeInfo = session.map(r => {
-            const label = r.type === 'raw' ? 'R' : 'P';
+            const label = typeLabels[r.type] || r.type;
             return label + ':' + r.sizeMB + 'MB';
           }).join(' / ');
 
@@ -147,22 +146,14 @@ const RecordingsView = {
           const rightCol = document.createElement('div');
           rightCol.className = 'd-flex align-items-center gap-1';
 
-          if (raw) {
-            const btnRaw = document.createElement('button');
-            btnRaw.className = 'btn btn-outline-success btn-sm';
-            btnRaw.title = 'Download Raw';
-            btnRaw.textContent = 'Raw';
-            btnRaw.addEventListener('click', () => this._downloadRecording(container, raw.filename, raw.sizeBytes));
-            rightCol.appendChild(btnRaw);
-          }
-
-          if (processed) {
-            const btnProc = document.createElement('button');
-            btnProc.className = 'btn btn-outline-primary btn-sm';
-            btnProc.title = 'Download Processed';
-            btnProc.textContent = 'Processed';
-            btnProc.addEventListener('click', () => this._downloadRecording(container, processed.filename, processed.sizeBytes));
-            rightCol.appendChild(btnProc);
+          const btnStyles = { hksv: 'btn-outline-warning', livestream: 'btn-outline-success', processed: 'btn-outline-primary', raw: 'btn-outline-success' };
+          for (const rec of session) {
+            const btn = document.createElement('button');
+            btn.className = 'btn ' + (btnStyles[rec.type] || 'btn-outline-secondary') + ' btn-sm';
+            btn.title = 'Download ' + (typeLabels[rec.type] || rec.type);
+            btn.textContent = typeLabels[rec.type] || rec.type;
+            btn.addEventListener('click', () => this._downloadRecording(container, rec.filename, rec.sizeBytes));
+            rightCol.appendChild(btn);
           }
 
           const btnDelete = document.createElement('button');
@@ -279,7 +270,7 @@ const RecordingsView = {
     const map = {};
     for (const rec of recs) {
       // Filename: <serial>_<timestamp>_<type>.mp4 — extract timestamp as session key
-      const match = rec.filename.match(/^[A-Za-z0-9_-]+?_(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:-\d{3}Z)?)_/);
+      const match = rec.filename.match(/^[A-Za-z0-9_-]+?_(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:-\d{3}Z)?)(?:_|\.mp4$)/);
       const key = match ? match[1] : rec.filename;
       if (!map[key]) map[key] = [];
       map[key].push(rec);
@@ -287,7 +278,10 @@ const RecordingsView = {
     // Sort sessions by newest first, within each session: raw before processed
     return Object.values(map)
       .sort((a, b) => (b[0].createdAt || 0) - (a[0].createdAt || 0))
-      .map(session => session.sort((a, b) => (a.type === 'raw' ? 0 : 1) - (b.type === 'raw' ? 0 : 1)));
+      .map(session => {
+        const order = { hksv: 0, livestream: 1, raw: 2, processed: 3 };
+        return session.sort((a, b) => (order[a.type] ?? 9) - (order[b.type] ?? 9));
+      });
   },
 
   _confirmDeleteAll(container) {

--- a/homebridge-ui/server.js
+++ b/homebridge-ui/server.js
@@ -1324,12 +1324,16 @@ class UiServer extends HomebridgePluginUiServer {
           try {
             const stats = fs.statSync(filePath);
             // Parse filename: <serial>_<timestamp>_<type>.mp4
-            const match = filename.match(/^([A-Za-z0-9_-]+?)_(\d{4}-\d{2}-\d{2}T[\d-]+Z?)(?:_(raw|processed))?\.mp4$/);
+            // Types: hksv, livestream (current), raw, processed (legacy)
+            const match = filename.match(/^([A-Za-z0-9_-]+?)_(\d{4}-\d{2}-\d{2}T[\d-]+Z?)(?:_(hksv|livestream|raw|processed))?\.mp4$/);
+            const rawType = match && match[3] ? match[3] : 'processed';
+            // Normalize legacy 'raw' → 'livestream'
+            const type = rawType === 'raw' ? 'livestream' : rawType;
             return {
               filename,
               serial: match ? match[1] : 'unknown',
               timestamp: match ? match[2] : '',
-              type: match && match[3] ? match[3] : 'processed',
+              type,
               sizeBytes: stats.size,
               sizeMB: (stats.size / (1024 * 1024)).toFixed(1),
               createdAt: stats.mtimeMs,

--- a/src/controller/DebugRecordingManager.ts
+++ b/src/controller/DebugRecordingManager.ts
@@ -4,6 +4,7 @@ import { mkdirSync, readdirSync, statSync, unlinkSync, createReadStream, openSyn
 import * as path from 'path';
 import * as net from 'net';
 import { StreamMetadata, AudioCodec } from 'eufy-security-client';
+import type { StreamTrigger } from './LocalLivestreamManager.js';
 import { ILogObj, Logger } from 'tslog';
 import { pickPort } from 'pick-port';
 
@@ -32,7 +33,7 @@ export interface DebugRecordingFile {
   filename: string;
   serial: string;
   timestamp: string;
-  type: 'raw' | 'processed';
+  type: 'hksv' | 'livestream' | 'processed';
   sizeBytes: number;
   createdAt: number;
 }
@@ -84,6 +85,7 @@ export class DebugRecordingManager {
     audiostream: Readable,
     metadata: StreamMetadata,
     sessionId?: string,
+    trigger?: StreamTrigger,
   ): Promise<string | null> {
     const sanitizedSerial = serial.replace(/[^A-Za-z0-9_-]/g, '');
 
@@ -93,7 +95,8 @@ export class DebugRecordingManager {
     }
 
     const ts = sessionId ?? new Date().toISOString().replace(/[:.]/g, '-');
-    const filename = `${sanitizedSerial}_${ts}_raw.mp4`;
+    const type = trigger ?? 'livestream';
+    const filename = `${sanitizedSerial}_${ts}_${type}.mp4`;
     const outputPath = path.join(this.recordingsDir, filename);
 
     const audioFormat = audioFormatForCodec(metadata.audioCodec);
@@ -419,11 +422,23 @@ export class DebugRecordingManager {
     }
   }
 
+  /** Map legacy type strings to current ones. */
+  private normalizeRecordingType(raw?: string): DebugRecordingFile['type'] {
+    switch (raw) {
+      case 'hksv': return 'hksv';
+      case 'livestream': return 'livestream';
+      case 'raw': return 'livestream'; // legacy
+      case 'processed': return 'processed';
+      default: return 'processed'; // legacy files without type suffix
+    }
+  }
+
   private parseRecordingFilename(filename: string): DebugRecordingFile | null {
     // Expected format: <serial>_<ISO-timestamp>_<type>.mp4
+    // Types: hksv, livestream (current), raw, processed (legacy)
     // or legacy: <serial>_<ISO-timestamp>.mp4 (processed, from existing debug recording)
     // Timestamp in filename: 2024-03-26T14-30-00-000Z (colons and dots replaced with hyphens)
-    const match = filename.match(/^([A-Za-z0-9_-]+?)_(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:-\d{3}Z)?)(?:_(raw|processed))?\.mp4$/);
+    const match = filename.match(/^([A-Za-z0-9_-]+?)_(\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}(?:-\d{3}Z)?)(?:_(hksv|livestream|raw|processed))?\.mp4$/);
     if (!match) return null;
 
     const filePath = path.join(this.recordingsDir, filename);
@@ -444,7 +459,7 @@ export class DebugRecordingManager {
         filename,
         serial: match[1],
         timestamp,
-        type: (match[3] as 'raw' | 'processed') ?? 'processed',
+        type: this.normalizeRecordingType(match[3]),
         sizeBytes: stats.size,
         createdAt: stats.mtimeMs,
       };

--- a/src/controller/LocalLivestreamManager.ts
+++ b/src/controller/LocalLivestreamManager.ts
@@ -6,6 +6,9 @@ import { ILogObj, Logger } from 'tslog';
 import { PREBUFFER_DURATION_MS, PREBUFFER_ESTIMATED_BYTE_RATE } from '../settings.js';
 import { DebugRecordingManager } from './DebugRecordingManager.js';
 
+/** What triggered the P2P livestream — used to tag debug recordings. */
+export type StreamTrigger = 'hksv' | 'livestream';
+
 /** Internal state: streams plus a timestamp for dedup/reuse logic. */
 interface ActiveStream {
   videostream: Readable;
@@ -14,6 +17,8 @@ interface ActiveStream {
   createdAt: number;
   /** Shared ID linking raw + processed debug recordings from the same session. */
   sessionId: string;
+  /** What triggered this P2P stream (HKSV motion or manual livestream). */
+  trigger: StreamTrigger;
 }
 
 /** Data returned to consumers — only the streams they need. */
@@ -78,6 +83,8 @@ export class LocalLivestreamManager {
   private stopGraceTimer: NodeJS.Timeout | null = null;
   /** Number of consumers currently holding a forked copy of the stream. */
   private activeConsumers = 0;
+  /** Trigger that started (or will start) the current P2P stream. */
+  private streamTrigger: StreamTrigger = 'livestream';
 
   /** Ring buffer for raw video data captured during pre-warm (no consumers). */
   private videoBuffer: StreamBuffer | null = null;
@@ -151,7 +158,7 @@ export class LocalLivestreamManager {
    * for other consumers.  A consumer count tracks active forks so the P2P
    * session is only stopped when the last consumer calls stopLocalLiveStream().
    */
-  public async getLocalLiveStream(): Promise<LivestreamData> {
+  public async getLocalLiveStream(trigger?: StreamTrigger): Promise<LivestreamData> {
     if (this.stopGraceTimer) {
       clearTimeout(this.stopGraceTimer);
       this.stopGraceTimer = null;
@@ -159,6 +166,7 @@ export class LocalLivestreamManager {
     }
 
     if (!this.stationStream) {
+      if (trigger) this.streamTrigger = trigger;
       await this.startLocalLiveStream();
     }
 
@@ -238,6 +246,7 @@ export class LocalLivestreamManager {
     if (this.isStreamActive()) {
       return;
     }
+    this.streamTrigger = 'hksv';
     await this.startLocalLiveStream();
     // Stream is now active but has zero consumers.
     // Schedule a grace-period stop so it doesn't run forever if unused.
@@ -423,7 +432,9 @@ export class LocalLivestreamManager {
     this.log.debug('Stream metadata:', JSON.stringify(metadata));
 
     const sessionId = new Date().toISOString().replace(/[:.]/g, '-');
-    this.stationStream = { videostream, audiostream, metadata, createdAt: Date.now(), sessionId };
+    const trigger = this.streamTrigger;
+    this.streamTrigger = 'livestream'; // reset for next stream
+    this.stationStream = { videostream, audiostream, metadata, createdAt: Date.now(), sessionId, trigger };
 
     // Start prebuffering video data. If a consumer is already waiting (pending
     // resolve), forkStream will drain the buffer immediately. If this is a
@@ -438,7 +449,7 @@ export class LocalLivestreamManager {
       const rawVideoFork = new PassThrough();
       const rawAudioFork = new PassThrough();
       this.debugRecordingManager.startRawRecording(
-        this.serialNumber, rawVideoFork, rawAudioFork, metadata, sessionId,
+        this.serialNumber, rawVideoFork, rawAudioFork, metadata, sessionId, trigger,
       ).then(() => {
         videostream.pipe(rawVideoFork);
         audiostream.pipe(rawAudioFork);

--- a/src/controller/recordingDelegate.ts
+++ b/src/controller/recordingDelegate.ts
@@ -112,7 +112,7 @@ export class RecordingDelegate implements CameraRecordingDelegate {
       videoParams.setInputSource(url);
       audioParams.setInputSource(url);
     } else {
-      const streamData = await this.localLivestreamManager.getLocalLiveStream();
+      const streamData = await this.localLivestreamManager.getLocalLiveStream('hksv');
       await videoParams.setInputStream(streamData.videostream);
       applyP2PAudioFormat(audioParams, streamData.metadata.audioCodec);
       await audioParams.setInputStream(streamData.audiostream);

--- a/src/controller/streamingDelegate.ts
+++ b/src/controller/streamingDelegate.ts
@@ -295,7 +295,7 @@ export class StreamingDelegate implements CameraStreamingDelegate {
       `Using P2P local livestream for ${this.device.getName()} ` +
       `(serial: ${this.device.getSerial()}, type: ${this.device.getDeviceType()})`,
     );
-    const streamData = await this.localLivestreamManager.getLocalLiveStream();
+    const streamData = await this.localLivestreamManager.getLocalLiveStream('livestream');
     this.log.debug('Livestream obtained successfully. Setting up FFmpeg input streams...');
     await videoParams.setInputStream(streamData.videostream);
     if (audioParams) {


### PR DESCRIPTION
## Summary

Debug recordings are now tagged with what triggered the P2P stream — `hksv` (motion-triggered HKSV recording) or `livestream` (manual Home app stream). This makes it immediately clear which recording corresponds to which event when reviewing debug files.

### Changes

- **Filename format**: `<serial>_<timestamp>_hksv.mp4` or `<serial>_<timestamp>_livestream.mp4` (replaces generic `_raw` suffix)
- **Trigger tracking**: `LocalLivestreamManager` tracks whether the P2P stream was started by `preWarmStream()` (HKSV) or `getLocalLiveStream('livestream')` (manual stream)
- **UI**: Recordings list shows type-specific labels and button colors (HKSV = yellow, Livestream = green)
- **Backward compat**: Legacy `_raw.mp4` files are recognized and displayed as "Livestream"

## Test plan

- [ ] Enable Debug Livestream, restart plugin
- [ ] Trigger motion on a camera — verify recording filename contains `_hksv.mp4`
- [ ] Manually open camera in Home app — verify recording filename contains `_livestream.mp4`
- [ ] Check recordings UI shows correct labels and colors for each type
- [ ] Place a legacy `_raw.mp4` file in recordings dir — verify it appears as "Live" in the UI
