### PR TITLE
fix: skip npm publish on GitHub pre-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,13 @@ jobs:
       - name: Determine release type
         id: release-type
         run: |
-          if [[ "${{ github.event_name }}" == "release" ]]; then
+          if [[ "${{ github.event_name }}" == "release" && "${{ github.event.release.prerelease }}" != "true" ]]; then
             echo "type=latest" >> $GITHUB_OUTPUT
             echo "tag=latest" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "release" && "${{ github.event.release.prerelease }}" == "true" ]]; then
+            echo "type=none" >> $GITHUB_OUTPUT
+            echo "tag=none" >> $GITHUB_OUTPUT
+            echo "Pre-release detected — skipping publish (beta/alpha are published via branch push)"
           elif [[ "${{ github.ref }}" == refs/heads/beta-* ]]; then
             echo "type=beta" >> $GITHUB_OUTPUT
             echo "tag=beta" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

Creating a GitHub pre-release (e.g. `v4.6.1-beta.1`) triggered the release workflow which published to npm with the `latest` tag instead of skipping. This caused `4.6.1` to be published to `latest` prematurely.

The workflow now checks `github.event.release.prerelease` — pre-releases are skipped since beta/alpha publishes are already handled by the branch push trigger.
