### PR TITLE
fix: skip release workflow entirely for GitHub pre-releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,9 @@ concurrency:
 
 jobs:
   publish:
-    if: ${{ github.repository == 'homebridge-plugins/homebridge-eufy-security' }}
+    if: >-
+      github.repository == 'homebridge-plugins/homebridge-eufy-security'
+      && !(github.event_name == 'release' && github.event.release.prerelease)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -47,13 +49,9 @@ jobs:
       - name: Determine release type
         id: release-type
         run: |
-          if [[ "${{ github.event_name }}" == "release" && "${{ github.event.release.prerelease }}" != "true" ]]; then
+          if [[ "${{ github.event_name }}" == "release" ]]; then
             echo "type=latest" >> $GITHUB_OUTPUT
             echo "tag=latest" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "release" && "${{ github.event.release.prerelease }}" == "true" ]]; then
-            echo "type=none" >> $GITHUB_OUTPUT
-            echo "tag=none" >> $GITHUB_OUTPUT
-            echo "Pre-release detected — skipping publish (beta/alpha are published via branch push)"
           elif [[ "${{ github.ref }}" == refs/heads/beta-* ]]; then
             echo "type=beta" >> $GITHUB_OUTPUT
             echo "tag=beta" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary

The previous fix checked pre-release status inside the workflow steps, but the job still triggered — allocating a runner, checking out code, and installing dependencies before skipping.

This moves the guard to the job-level `if` condition so the entire job is skipped immediately when a GitHub pre-release is published. No runner allocated, no wasted CI time.
