### PR TITLE
chore: switch to scoped eufy-security-client for beta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@homebridge/plugin-ui-utils": "^2.2.2",
-        "eufy-security-client": "dev",
+        "eufy-security-client": "npm:@homebridge-eufy-security/eufy-security-client@^3.8.0-dev.8",
         "ffmpeg-for-homebridge": "2.2.2",
         "pick-port": "^2.2.0",
         "rotating-file-stream": "^3.2.9",
@@ -1425,9 +1425,10 @@
       }
     },
     "node_modules/eufy-security-client": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/eufy-security-client/-/eufy-security-client-3.8.0.tgz",
-      "integrity": "sha512-aVEJKTrlZvX5d0lOhXaRakJ/Msp3/YcPjF75tAiUxFPymKYtAzYK0u7leL7JMLPNfL3gdvNhOa8vmGyTGNaAvA==",
+      "name": "@homebridge-eufy-security/eufy-security-client",
+      "version": "3.8.0-dev.8",
+      "resolved": "https://registry.npmjs.org/@homebridge-eufy-security/eufy-security-client/-/eufy-security-client-3.8.0-dev.8.tgz",
+      "integrity": "sha512-9WkVLbwN3Rm1he55PSzKcMmnPHTyiO0gtYL14BYkWKu0cvA2XnZB9F+Otv7gSFa6mZ9B1gul2C3GD3VUZmTnQw==",
       "license": "MIT",
       "dependencies": {
         "@cospired/i18n-iso-languages": "^4.2.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   ],
   "dependencies": {
     "@homebridge/plugin-ui-utils": "^2.2.2",
-    "eufy-security-client": "dev",
+    "eufy-security-client": "npm:@homebridge-eufy-security/eufy-security-client@^3.8.0-dev.8",
     "ffmpeg-for-homebridge": "2.2.2",
     "pick-port": "^2.2.0",
     "rotating-file-stream": "^3.2.9",


### PR DESCRIPTION
## Summary

Switch the beta branch to use the scoped `@homebridge-eufy-security/eufy-security-client` package (via npm alias) instead of bropat's upstream `eufy-security-client`.

This picks up all 10 open upstream PRs that have been waiting for merge:
- #795 — ECDH encryption for T8214/T8425
- #828 — missing GenericTypeProperty labels
- #830 — indoor cameras on HomeBase livestream routing
- #831 — configurable P2P stream timeouts
- #832 — SoloCam E42 rtspStreamUrl property
- #834 — E340 MiniBase Chime livestream fix
- #852 — ADTS multi-RDB frame normalization
- #854 — NVR S4 Max (T8N00) support
- #855 — PoE Bullet-PTZ Cam S4 (T8E00) support
- #858 — LOCK_85V0 registration

Uses npm aliasing (`"eufy-security-client": "npm:@homebridge-eufy-security/..."`), so zero import changes are needed in source code.

Published from the `beta-dev` branch on `lenoxys/eufy-security-client`.
