### PR TITLE
Prune all stale services by snapshotting the list before removal (#906)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,9 +47,13 @@ jobs:
       - name: Determine release type
         id: release-type
         run: |
-          if [[ "${{ github.event_name }}" == "release" ]]; then
+          if [[ "${{ github.event_name }}" == "release" && "${{ github.event.release.prerelease }}" != "true" ]]; then
             echo "type=latest" >> $GITHUB_OUTPUT
             echo "tag=latest" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "release" && "${{ github.event.release.prerelease }}" == "true" ]]; then
+            echo "type=none" >> $GITHUB_OUTPUT
+            echo "tag=none" >> $GITHUB_OUTPUT
+            echo "Pre-release detected — skipping publish (beta/alpha are published via branch push)"
           elif [[ "${{ github.ref }}" == refs/heads/beta-* ]]; then
             echo "type=beta" >> $GITHUB_OUTPUT
             echo "tag=beta" >> $GITHUB_OUTPUT

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,9 @@ concurrency:
 
 jobs:
   publish:
-    if: ${{ github.repository == 'homebridge-plugins/homebridge-eufy-security' }}
+    if: >-
+      github.repository == 'homebridge-plugins/homebridge-eufy-security'
+      && !(github.event_name == 'release' && github.event.release.prerelease)
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -47,13 +49,9 @@ jobs:
       - name: Determine release type
         id: release-type
         run: |
-          if [[ "${{ github.event_name }}" == "release" && "${{ github.event.release.prerelease }}" != "true" ]]; then
+          if [[ "${{ github.event_name }}" == "release" ]]; then
             echo "type=latest" >> $GITHUB_OUTPUT
             echo "tag=latest" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "release" && "${{ github.event.release.prerelease }}" == "true" ]]; then
-            echo "type=none" >> $GITHUB_OUTPUT
-            echo "tag=none" >> $GITHUB_OUTPUT
-            echo "Pre-release detected — skipping publish (beta/alpha are published via branch push)"
           elif [[ "${{ github.ref }}" == refs/heads/beta-* ]]; then
             echo "type=beta" >> $GITHUB_OUTPUT
             echo "tag=beta" >> $GITHUB_OUTPUT

--- a/src/accessories/BaseAccessory.ts
+++ b/src/accessories/BaseAccessory.ts
@@ -355,7 +355,11 @@ export abstract class BaseAccessory extends EventEmitter {
   }
 
   protected pruneUnusedServices() {
-    this.accessory.services.forEach((service) => {
+    // Snapshot the services list first: removeService() splices the very array
+    // backing accessory.services, so iterating it live would skip the element
+    // after each removal and leave stale services (e.g. disabled Switch
+    // buttons) behind in HomeKit.
+    [...this.accessory.services].forEach((service) => {
       if (
         !this.servicesInUse.includes(service) &&
         !BaseAccessory.CAMERA_CONTROLLER_SERVICE_UUIDS.has(service.UUID)


### PR DESCRIPTION
### Problem

When camera button switches (e.g. **Enable**, **Indoor Chime**) are disabled in the config, the switches still remain in HomeKit instead of being removed.

### Root cause

`setupButtonService()` correctly skips *creating* a service when its config value is falsy, so the offending switches are **stale cached services** that should be removed by `pruneUnusedServices()` (`src/accessories/BaseAccessory.ts`). But that method iterates the live array:

```js
this.accessory.services.forEach((service) => { ... this.accessory.removeService(service) ... });
```

`Accessory.removeService()` does `this.services.splice(index, 1)` on the **same array** `forEach` is walking. Removing an element shifts every later element left while `forEach` keeps advancing its index, so the element immediately after each removed one is **skipped**. With two consecutive stale services (Enable + Indoor Chime), the second survives — exactly the reported symptom.

### Fix

Iterate over a snapshot so removals can't perturb the walk:

```js
[...this.accessory.services].forEach((service) => { ... });
```

The keep/remove predicate (`servicesInUse` + `CAMERA_CONTROLLER_SERVICE_UUIDS`) is unchanged — only *which* services get visited is corrected.

### Validation (no hardware required)

Independent repro against HAP-NodeJS's real `removeService` splice behaviour: the live-`forEach` version leaves "Indoor Chime" behind; the snapshot version removes all stale services (and the all-stale edge case goes from 1-left to 0-left). `npm run build` (tsc) and `npm run lint` (`eslint --max-warnings=0`) both pass. `pruneUnusedServices` is the only `removeService` loop in `src/`. No secrets in the diff.

### Note

I did not bump `package.json` (the repo derives `version.ts` from it at prebuild) — please apply your usual release label/version bump.

Fixes #906
