### PR TITLE
fix: revert tslog to v4 (hotfix v4.7.1)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@homebridge-plugins/homebridge-eufy-security",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@homebridge-plugins/homebridge-eufy-security",
-      "version": "4.7.0",
+      "version": "4.7.1",
       "funding": [
         {
           "type": "github",
@@ -21,7 +21,7 @@
         "pick-port": "^2.2.1",
         "rotating-file-stream": "^3.2.9",
         "tar": "^7.5.20",
-        "tslog": "^5.0.0"
+        "tslog": "^4.10.2"
       },
       "devDependencies": {
         "@types/node": "^26.1.1",
@@ -2376,15 +2376,12 @@
       "license": "0BSD"
     },
     "node_modules/tslog": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/tslog/-/tslog-5.0.0.tgz",
-      "integrity": "sha512-ro4kpyeDWxInGB0CK0+hS3USFu/Z/E5QDY99v5wOUqztecDj0rVOQdXUOBBiT0bQk1pw+kpduk4BwPBF5xkQ5g==",
+      "version": "4.11.0",
+      "resolved": "https://registry.npmjs.org/tslog/-/tslog-4.11.0.tgz",
+      "integrity": "sha512-gBe0FTKkRpOv3DenGipjQWQe073jNd1cOLj3nYfVM0/NP29sQzAIx6kfyfTTsQOiWMC+B+tSr289lNXtu7HCmQ==",
       "license": "MIT",
-      "bin": {
-        "tslog": "esm/subpaths/cli.js"
-      },
       "engines": {
-        "node": ">=20"
+        "node": ">=16"
       },
       "funding": {
         "url": "https://github.com/fullstack-build/tslog?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "displayName": "Homebridge Eufy Security",
   "name": "@homebridge-plugins/homebridge-eufy-security",
-  "version": "4.7.0",
+  "version": "4.7.1",
   "description": "Control Eufy Security from homebridge.",
   "type": "module",
   "license": "Apache-2.0",
@@ -48,7 +48,7 @@
     "pick-port": "^2.2.1",
     "rotating-file-stream": "^3.2.9",
     "tar": "^7.5.20",
-    "tslog": "^5.0.0"
+    "tslog": "^4.10.2"
   },
   "devDependencies": {
     "@types/node": "^26.1.1",


### PR DESCRIPTION
## Problem

v4.7.0 bumped `tslog` from v4 to v5 as part of a blanket dependency refresh. tslog v5 is a breaking API change: the v4 logger options (`prettyLogTemplate`, `stylePrettyLogs`, etc.) were removed, and the transport record shape changed (`_meta` no longer exists). This caused two regressions on every startup:

- Repeated `tslog: "..." was removed in v5` warnings.
- `attached transport threw an error TypeError: Cannot read properties of undefined (reading 'name')` on every log line, because the file transport reads `logObj._meta.name`.

Log files and console output were effectively broken.

## Fix

Revert `tslog` to `^4.10.2`. The existing logging code (`src/utils/utils.ts`, `src/platform.ts`) is written against the v4 API, so this restores known-good behavior with no code changes.

A proper migration to tslog v5 should be done separately on a beta branch, where the logger options and transport handler can be ported and tested.

## Verification
- `npm install` — tslog@4.11.0
- `npm run build` — OK
- `npm run lint` — OK

Hotfix release: **v4.7.1**.
