### PR TITLE
chore: auto-close new issues and PRs (project frozen on esc deprecation)

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -1,0 +1,84 @@
+name: Auto-close (project frozen)
+
+# The upstream eufy-security-client library has been deprecated by its maintainer.
+# Eufy has migrated its apps to a new "Mega" protocol, and a brand-new library is
+# being built against it. Until that lands, this plugin is frozen: no new features
+# or device support can be added, and most breakages originate upstream.
+#
+# This workflow posts an explanation on every newly opened issue and pull request
+# and closes it immediately.
+
+on:
+  issues:
+    types: [opened]
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: auto-close-${{ github.event.issue.number || github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  auto-close:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Comment and close
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const isPR = !!context.payload.pull_request;
+            const number = isPR
+              ? context.payload.pull_request.number
+              : context.payload.issue.number;
+
+            const intro = isPR
+              ? "Thank you for the pull request."
+              : "Thank you for taking the time to open this issue.";
+
+            const body = [
+              intro,
+              "",
+              "**This project is currently frozen.**",
+              "",
+              "The plugin relies on [`eufy-security-client`](https://github.com/bropat/eufy-security-client), which its maintainer has **deprecated**. Eufy has moved its apps to a new **\"Mega\"** protocol, and a brand-new library is being built against it. All development effort is going there.",
+              "",
+              "What this means for now:",
+              "- ✅ The current version keeps working as-is for devices still on the old protocol.",
+              "- 🧊 No new features or new device support can be added.",
+              "- 🩹 Only strictly necessary fixes for critical breakages will be considered.",
+              "- 🚀 Effort is focused on the new Mega-protocol library first. Work to adopt it in this plugin **has not started yet**.",
+              "",
+              "**ETA:** work on this plugin is not expected to begin before **mid-August 2026**, and only once the underlying library is ready.",
+              "",
+              "Because of this, we are automatically closing new issues and pull requests until the migration is complete. This is not a reflection on your report — we simply cannot action it right now.",
+              "",
+              "Please watch the repository and the upstream [deprecation notice](https://github.com/bropat/eufy-security-client) for updates. Thank you for your patience. 🙏",
+            ].join("\n");
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body,
+            });
+
+            if (isPR) {
+              await github.rest.pulls.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: number,
+                state: "closed",
+              });
+            } else {
+              await github.rest.issues.update({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: number,
+                state: "closed",
+                state_reason: "not_planned",
+              });
+            }


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow that automatically comments on and immediately closes every newly opened issue and pull request.

## Why

`eufy-security-client` has been deprecated upstream. Eufy migrated its apps to the new "Mega" protocol, and a replacement library is being built against it. Work to adopt that library in this plugin has not started and is not expected before mid-August 2026. Until then the project is frozen — no new features or device support, only strictly necessary critical fixes.

Rather than let new reports and PRs accumulate unanswered, this workflow gives everyone a consistent explanation and sets expectations.

## Behavior

- Triggers on `issues: opened` and `pull_request_target: opened`.
- Posts a standard message: deprecation context, what is/isn't happening, and a mid-August 2026 ETA.
- Closes issues as `not planned`; closes PRs.
- Does not check out or run any PR code (safe use of `pull_request_target`), and only needs `issues: write` / `pull-requests: write`.

## Notes

- Existing open issues/PRs are unaffected — this only fires on newly opened items.
- Revert or disable the workflow once plugin work resumes.
