### PR TITLE
fix: exempt maintainers and keep-open label from auto-close

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -31,9 +31,19 @@ jobs:
         with:
           script: |
             const isPR = !!context.payload.pull_request;
-            const number = isPR
-              ? context.payload.pull_request.number
-              : context.payload.issue.number;
+            const node = isPR ? context.payload.pull_request : context.payload.issue;
+            const number = node.number;
+
+            // Never auto-close items opened by the maintainers/team, nor anything
+            // explicitly flagged to stay open. This lets us keep working in the repo
+            // while the project is frozen for outside contributors.
+            const association = node.author_association;
+            const exemptAssociations = ["OWNER", "MEMBER", "COLLABORATOR"];
+            const labels = (node.labels || []).map((l) => (typeof l === "string" ? l : l.name));
+            if (exemptAssociations.includes(association) || labels.includes("keep-open")) {
+              core.info(`Skipping auto-close for #${number} (association=${association}, labels=${labels.join(",")})`);
+              return;
+            }
 
             const intro = isPR
               ? "Thank you for the pull request."


### PR DESCRIPTION
## Summary

Adds a maintainer/team guard to the auto-close workflow so it no longer closes our own work.

## Why

The auto-close workflow (merged in #955) fires on every newly opened issue and PR. As-is it would also close issues and PRs opened by the maintainers and org team — including the branches we use to keep working while the project is frozen.

## Change

Before commenting/closing, the workflow now skips when:

- the author's `author_association` is `OWNER`, `MEMBER`, or `COLLABORATOR`, or
- the item carries a `keep-open` label (manual escape hatch for anything else worth keeping).

Outside contributors and bots (e.g. dependabot) are still auto-closed with the deprecation message.

## Verification
- Workflow YAML validated.
