### PR TITLE
chore: add Discord invite to auto-close message

### DIFF
--- a/.github/workflows/auto-close.yml
+++ b/.github/workflows/auto-close.yml
@@ -66,7 +66,11 @@ jobs:
               "",
               "Because of this, we are automatically closing new issues and pull requests until the migration is complete. This is not a reflection on your report — we simply cannot action it right now.",
               "",
-              "Please watch the repository and the upstream [deprecation notice](https://github.com/bropat/eufy-security-client) for updates. Thank you for your patience. 🙏",
+              "Please watch the repository and the upstream [deprecation notice](https://github.com/bropat/eufy-security-client) for updates.",
+              "",
+              "💬 For questions and discussion, join us on [Discord](https://discord.gg/dH32NKWst3).",
+              "",
+              "Thank you for your patience. 🙏",
             ].join("\n");
 
             await github.rest.issues.createComment({


### PR DESCRIPTION
Adds a Discord invite link to the auto-close message so users have somewhere to ask questions while the project is frozen.